### PR TITLE
update to use vector structured logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,6 +152,9 @@ services:
       retries: 3
     environment:
       LOGFLARE_PUBLIC_ACCESS_TOKEN: ${LOGFLARE_PUBLIC_ACCESS_TOKEN}
+      AWS_REGION: ${AWS_REGION}
+      PROJECT_ID: ${PROJECT_ID}
+      HOSTNAME_OVERRIDE: ${HOSTNAME_OVERRIDE}
     command:
       [
         "--config",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,10 @@ services:
       - ACCESS_API_KEY=${ACCESS_API_KEY:-}
       - AWS_S3_BUCKET=${AWS_S3_BUCKET:-}
       - AWS_INSTANCE_PROFILE_NAME=${AWS_INSTANCE_PROFILE_NAME}
+      # Analytics (CloudWatch)
+      - ANALYTICS_PROVIDER=${ANALYTICS_PROVIDER:-cloudwatch}
+      - CLOUDWATCH_LOG_GROUP=${CLOUDWATCH_LOG_GROUP}
+      - HOSTNAME_OVERRIDE=${HOSTNAME_OVERRIDE:-}
     networks:
       - insforge-network
 

--- a/docker-init/logs/vector.yml
+++ b/docker-init/logs/vector.yml
@@ -198,3 +198,31 @@ sinks:
     encoding:
       codec: 'json'
     compression: 'gzip'
+  # CloudWatch structured sinks (Vector -> CloudWatch). Use distinct stream names to avoid conflicts
+  cw_insforge:
+    type: aws_cloudwatch_logs
+    inputs:
+      - insforge_logs
+    region: ${AWS_REGION}
+    group_name: /insforge/${PROJECT_ID}
+    stream_name: ${HOSTNAME_OVERRIDE}-insforge-vector
+    encoding:
+      codec: json
+  cw_rest:
+    type: aws_cloudwatch_logs
+    inputs:
+      - rest_logs
+    region: ${AWS_REGION}
+    group_name: /insforge/${PROJECT_ID}
+    stream_name: ${HOSTNAME_OVERRIDE}-postgrest-vector
+    encoding:
+      codec: json
+  cw_db:
+    type: aws_cloudwatch_logs
+    inputs:
+      - db_logs
+    region: ${AWS_REGION}
+    group_name: /insforge/${PROJECT_ID}
+    stream_name: ${HOSTNAME_OVERRIDE}-postgres-vector
+    encoding:
+      codec: json


### PR DESCRIPTION
Tested in cloud: http://3.14.8.40:7130/dashboard/analytics 
<img width="1709" height="983" alt="image" src="https://github.com/user-attachments/assets/b015835b-9da8-4c2d-b8f0-eed0ffb38bff" />

The cloudwatch log groups:
https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Finsforge$252Finsforge-walt-test

<img width="1945" height="844" alt="image" src="https://github.com/user-attachments/assets/a92060fd-e5a4-471b-8901-d614fc906dbc" />



## To write/read logs group, the IAM roles requires:
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "logs:CreateLogGroup",
                "logs:CreateLogStream",
                "logs:DescribeLogStreams",
                "logs:PutLogEvents",
                "logs:PutRetentionPolicy"
            ],
            "Resource": "*"
        }
    ]
}
```


## Env setup in here:
https://github.com/InsForge/insforge-cloud-backend/pull/71 