### PR TITLE
set the vector to use cloudwatch logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,10 @@ services:
       - ACCESS_API_KEY=${ACCESS_API_KEY:-}
       - AWS_S3_BUCKET=${AWS_S3_BUCKET:-}
       - AWS_INSTANCE_PROFILE_NAME=${AWS_INSTANCE_PROFILE_NAME}
+      # Analytics (CloudWatch)
+      - ANALYTICS_PROVIDER=${ANALYTICS_PROVIDER:-cloudwatch}
+      - CLOUDWATCH_LOG_GROUP=${CLOUDWATCH_LOG_GROUP}
+      - HOSTNAME_OVERRIDE=${HOSTNAME_OVERRIDE:-}
     networks:
       - insforge-network
 
@@ -152,6 +156,9 @@ services:
       retries: 3
     environment:
       LOGFLARE_PUBLIC_ACCESS_TOKEN: ${LOGFLARE_PUBLIC_ACCESS_TOKEN}
+      AWS_REGION: ${AWS_REGION:-us-east-2}
+      PROJECT_ID: ${PROJECT_ID:-}
+      HOSTNAME_OVERRIDE: ${HOSTNAME_OVERRIDE:-}
     command:
       [
         "--config",

--- a/docker-init/logs/vector.yml
+++ b/docker-init/logs/vector.yml
@@ -198,3 +198,32 @@ sinks:
     encoding:
       codec: 'json'
     compression: 'gzip'
+    
+  # CloudWatch structured sinks (Vector -> CloudWatch). Use distinct stream names to avoid conflicts
+  cw_insforge:
+    type: aws_cloudwatch_logs
+    inputs:
+      - insforge_logs
+    region: ${AWS_REGION}
+    group_name: /insforge/${PROJECT_ID}
+    stream_name: ${HOSTNAME_OVERRIDE}-insforge-vector
+    encoding:
+      codec: json
+  cw_rest:
+    type: aws_cloudwatch_logs
+    inputs:
+      - rest_logs
+    region: ${AWS_REGION}
+    group_name: /insforge/${PROJECT_ID}
+    stream_name: ${HOSTNAME_OVERRIDE}-postgrest-vector
+    encoding:
+      codec: json
+  cw_db:
+    type: aws_cloudwatch_logs
+    inputs:
+      - db_logs
+    region: ${AWS_REGION}
+    group_name: /insforge/${PROJECT_ID}
+    stream_name: ${HOSTNAME_OVERRIDE}-postgres-vector
+    encoding:
+      codec: json


### PR DESCRIPTION
Fixed the vector build error that blocks yesterdays build:
```
[ec2-user@ip-10-0-87-94 insforge-standalone]$ docker logs insforge-vector
2025-08-21T03:17:38.363742Z  INFO vector::app: Internal log rate limit configured. internal_log_rate_secs=10
2025-08-21T03:17:38.373168Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,lapin=info,kube=info"
2025-08-21T03:17:38.381228Z  INFO vector::app: Loading configs. paths=["/etc/vector/vector.yml"]
2025-08-21T03:17:38.407420Z ERROR vector::cli: Configuration error. error=sinks.cw_insforge.region: invalid type: unit value, expected any valid TOML value at line 206 column 12
2025-08-21T03:17:40.414915Z  INFO vector::app: Internal log rate limit configured. internal_log_rate_secs=10
2025-08-21T03:17:40.429426Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,lapin=info,kube=info"
2025-08-21T03:17:40.437071Z
error logs
```

The failure reason is because we don't have init aws_region setup when starts the vector, we use the us-east-2 as default aws region, this will bypass the vector check. 

original commit: https://github.com/InsForge/insforge-standalone/commit/08fb97e3434dc68c0b7fb3821926789db35c520f