### PR TITLE
revert oss version to v2.0.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.0.3}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.0.2}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
## Summary
- Revert default `INSFORGE_OSS_VER` in docker-compose.yml from `v2.0.3` back to `v2.0.2`.

## Test plan
- [ ] Confirm `docker compose up` pulls `ghcr.io/insforge/insforge-oss:v2.0.2` by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert default `insforge` image tag to v2.0.2
> Rolls back the default `INSFORGE_OSS_VER` value in [docker-compose.yml](https://github.com/InsForge/insforge-standalone/pull/59/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3) from v2.0.3 to v2.0.2. This affects deployments where `INSFORGE_OSS_VER` is not explicitly set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0fd7ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default container image version for service deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->