### PR TITLE
bump oss version to 2.0.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.0.4}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.0.5}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Bump default `insforge-oss` image version to v2.0.5
Updates the default image tag in [docker-compose.yml](https://github.com/InsForge/insforge-standalone/pull/61/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3) from `v2.0.4` to `v2.0.5`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9482cfe.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->