### PR TITLE
bump insforge version to v2.0.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.0.6}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.0.8}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
Bumps the \`INSFORGE_OSS_VER\` default from \`v2.0.6\` to \`v2.0.8\` in \`docker-compose.yml\`.

## Release context
- v2.0.7 release failed on the merge-manifests step (see InsForge/InsForge#1134 for the fix)
- Skipping 2.0.7 and cutting 2.0.8 from the fixed workflow (InsForge/InsForge#1135 bumps root package to 2.0.8)
- The \`ghcr.io/insforge/insforge-oss:v2.0.8\` image does NOT exist yet — merge this only AFTER the v2.0.8 tag push completes successfully in the main repo

## Test plan
- [ ] Wait for InsForge/InsForge v2.0.8 release to complete (image published to GHCR)
- [ ] After merge, verify \`docker compose pull\` succeeds against the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default insforge service deployment version to v2.0.8 (from v2.0.6).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->