### PR TITLE
bump oss version to v2.0.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.0.6}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.0.8}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
## Summary
- Bumps default `INSFORGE_OSS_VER` in `docker-compose.yml` from `v2.0.6` → `v2.0.8`.

## Test plan
- [ ] Confirm `ghcr.io/insforge/insforge-oss:v2.0.8` image exists and pulls cleanly
- [ ] `docker compose up` starts the insforge container on v2.0.8 without errors
- [ ] Smoke-test admin/API endpoints against the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default service version to v2.0.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->