### PR TITLE
chore: bump default INSFORGE_OSS_VER to v2.1.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.0.9}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.0}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
Bumps the default `INSFORGE_OSS_VER` in `docker-compose.yml` from v2.0.9 → v2.1.0.

Opened automatically by john-bot after releasing InsForge/InsForge v2.1.0.

Fresh standalone deployments will pull the new OSS image by default. Please review and merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated insforge service to version 2.1.0 in deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->