### PR TITLE
bump default INSFORGE_OSS_VER to v2.1.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.1}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.2}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump default `INSFORGE_OSS_VER` to v2.1.2 in docker-compose so deployments use `ghcr.io/insforge/insforge-oss:v2.1.2` by default. Ensures new installs pick up the latest patch fixes.

<sup>Written for commit a4c273f17f85d2e2b32a87107086e4781772b525. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated insforge application to version 2.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->