### PR TITLE
chore: bump default INSFORGE_OSS_VER to v2.1.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.2}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.3}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
Bumps the default `INSFORGE_OSS_VER` in `docker-compose.yml` from v2.1.2 → v2.1.3.

Opened automatically by john-bot after releasing InsForge/InsForge v2.1.3.

Fresh standalone deployments will pull the new OSS image by default. Please review and merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the default `INSFORGE_OSS_VER` in `docker-compose.yml` from v2.1.2 to v2.1.3 so fresh deployments pull the latest OSS image by default.

<sup>Written for commit abd968f70f719447d559298ea1c0adc20d19554c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default service image version to the latest patch release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/insforge-standalone/pull/74)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->