### PR TITLE
chore: bump default INSFORGE_OSS_VER to v2.1.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.2}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.4}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
Bumps the default `INSFORGE_OSS_VER` in `docker-compose.yml` from v2.1.2 → v2.1.4.

Opened automatically by john-bot after releasing InsForge/InsForge v2.1.4.

Fresh standalone deployments will pull the new OSS image by default. Please review and merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump the default `INSFORGE_OSS_VER` in `docker-compose.yml` from v2.1.2 to v2.1.4 so new deployments pull the latest `ghcr.io/insforge/insforge-oss` image by default.
Existing deployments that set the env var are unaffected.

<sup>Written for commit c58d926513a0de1f792ec2e6237b88e67d9f8ec4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default application service container image to the latest minor version for improved performance and stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/insforge-standalone/pull/75)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->