### PR TITLE
cap postgrest GHC heap so it releases memory back to the OS

### DIFF
--- a/auto-scale-memory.sh
+++ b/auto-scale-memory.sh
@@ -59,13 +59,18 @@ echo "Scaling factor: ${SCALE_FACTOR}"
 POSTGRES_MEM=$(awk "BEGIN {printf \"%.0f\", $POSTGRES_BASE * $SCALE_FACTOR}")
 INSFORGE_MEM=$(awk "BEGIN {printf \"%.0f\", $INSFORGE_BASE * $SCALE_FACTOR}")
 POSTGREST_MEM=$(awk "BEGIN {printf \"%.0f\", $POSTGREST_BASE * $SCALE_FACTOR}")
+# GHC heap cap for postgrest. Leave ~20MB for non-heap (binary, RTS internals,
+# thread stacks); floor at 20M to avoid pathological values on tiny instances.
+POSTGREST_RTS_HEAP=$(( POSTGREST_MEM - 20 ))
+if [ "$POSTGREST_RTS_HEAP" -lt 20 ]; then POSTGREST_RTS_HEAP=20; fi
+
 # Verify total doesn't exceed usable memory
 TOTAL_ALLOCATED=$(( POSTGRES_MEM + POSTGREST_MEM + INSFORGE_MEM ))
 
 echo ""
 echo "=== Calculated Memory Allocation ==="
 echo "postgres:      ${POSTGRES_MEM}MB (base: ${POSTGRES_BASE}MB)"
-echo "postgrest:     ${POSTGREST_MEM}MB (base: ${POSTGREST_BASE}MB)"
+echo "postgrest:     ${POSTGREST_MEM}MB (base: ${POSTGREST_BASE}MB, GHC heap cap: ${POSTGREST_RTS_HEAP}M)"
 echo "insforge:      ${INSFORGE_MEM}MB (base: ${INSFORGE_BASE}MB)"
 echo "---"
 echo "Total allocated: ${TOTAL_ALLOCATED}MB / ${USABLE_MEM}MB usable"
@@ -78,7 +83,7 @@ ENV_FILE=".env"
 cp "$ENV_FILE" "${ENV_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
 
 # Remove existing memory settings if present
-sed -i.tmp '/^POSTGRES_MEMORY=/d; /^POSTGREST_MEMORY=/d; /^INSFORGE_MEMORY=/d; /^DENO_MEMORY=/d; /^VECTOR_MEMORY=/d; /^NODE_EXPORTER_MEMORY=/d; /^# Auto-generated memory limits/d; /^# Total system memory:/d; /^# Usable memory:/d; /^# Scaling factor:/d' "$ENV_FILE"
+sed -i.tmp '/^POSTGRES_MEMORY=/d; /^POSTGREST_MEMORY=/d; /^POSTGREST_RTS_HEAP=/d; /^INSFORGE_MEMORY=/d; /^DENO_MEMORY=/d; /^VECTOR_MEMORY=/d; /^NODE_EXPORTER_MEMORY=/d; /^# Auto-generated memory limits/d; /^# Total system memory:/d; /^# Usable memory:/d; /^# Scaling factor:/d' "$ENV_FILE"
 rm -f "${ENV_FILE}.tmp"
 
 # Append new memory settings
@@ -90,6 +95,7 @@ cat >> "$ENV_FILE" << EOF
 # Scaling factor: ${SCALE_FACTOR}
 POSTGRES_MEMORY=${POSTGRES_MEM}M
 POSTGREST_MEMORY=${POSTGREST_MEM}M
+POSTGREST_RTS_HEAP=${POSTGREST_RTS_HEAP}M
 INSFORGE_MEMORY=${INSFORGE_MEM}M
 EOF
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,10 @@ services:
     image: postgrest/postgrest:v12.2.12
     container_name: insforge-postgrest
     restart: unless-stopped
+    # Cap GHC heap so postgrest releases memory back to the OS instead of
+    # idling near the cgroup limit. Heap target is set ~20MB below the
+    # cgroup limit by auto-scale-memory.sh (default suits the 50M base).
+    command: postgrest +RTS -M${POSTGREST_RTS_HEAP:-30M} -A2m -H24m -N1 -RTS
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary
- PostgREST containers on the fleet sit near their cgroup memory limit even when idle (observed 96.95% on a t4g.micro with 1 table, 0 active connections) because GHC's default RTS never returns touched pages to the OS. One NOTIFY-driven schema reload away from an OOM kill.
- Pass `+RTS -M<heap> -A2m -H24m -N1 -RTS` via the compose `command:` so GHC must GC and compact at the cap. `-N1` matches the `cpus: '0.3'` allocation (multi-capability would just waste per-thread overhead).
- `auto-scale-memory.sh` now emits `POSTGREST_RTS_HEAP=POSTGREST_MEMORY-20M` (floored at 20M) so a fixed ~20 MiB stays available for non-heap GHC overhead at every fleet size.

## Why a fixed 20 MiB offset (not a percentage)
GHC's non-heap footprint (binary + RTS internals + thread stacks) is roughly absolute, not proportional. Fixed offset gives 60% of cgroup on nano (50M → 30M heap), ~98% on large (980M → 960M heap) — both correct.

## Verification
On the live t4g.micro (10.0.102.176, project `testTelemtery`):
- Pre-fix: `insforge-postgrest 0.11% 123.1 MiB / 127 MiB (96.95%)` idle
- Schema cache size: 1 table / 8 columns / 56 functions → working set is trivially small
- Pool: 0 active connections, so the entire 123 MiB is GHC heap retention

Compose config validates clean. Auto-scale math at fleet sizes:

| POSTGREST_MEMORY | RTS heap cap | % of cgroup |
|-----------------:|-------------:|------------:|
| 50M (nano base)  | 30M          | 60%         |
| 127M (t4g.micro) | 107M         | 84%         |
| 275M (t3.small)  | 255M         | 93%         |
| 570M (t3.medium) | 550M         | 96%         |

## Test plan
- [ ] Apply on one t4g.micro instance, confirm idle memory drops from ~123 MiB to 40-60 MiB
- [ ] Re-run `auto-scale-memory.sh` on a t3.small, confirm `POSTGREST_RTS_HEAP=255M` written to .env
- [ ] Smoke test: hit the project's REST endpoint, confirm requests still served
- [ ] Watch for "heap exhausted" in logs after rollout — that would mean a tenant has a much larger schema than expected and the offset needs tuning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap the GHC heap for `postgrest/postgrest` to reduce idle memory and avoid OOMs during schema reloads. Heap cap auto-scales so the container returns memory to the OS when idle.

- **New Features**
  - `docker-compose.yml`: run `postgrest +RTS -M${POSTGREST_RTS_HEAP:-30M} -A2m -H24m -N1 -RTS` so GHC compacts at the cap and releases pages; default `30M` suits the unscaled base; `-N1` matches the `cpus: '0.3'` limit.
  - `auto-scale-memory.sh`: sets `POSTGREST_RTS_HEAP=POSTGREST_MEMORY-20M` (floor 20M), writes it to `.env`, removes old `POSTGREST_RTS_HEAP` entries, and shows the heap cap in the allocation summary.

<sup>Written for commit 7362a33d80e80980dfe844c4b88c02dcb21affd8. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/77?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced PostgREST memory handling to compute and enforce a per-process heap cap derived from scaled memory limits.
  * The environment regeneration now emits the computed heap cap so runtime uses the updated setting.
  * Allocation summary output now shows the calculated heap cap for clearer memory visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/insforge-standalone/pull/77)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->