### PR TITLE
quiet postgrest logs (warn vs info)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       PGRST_DB_POOL_ACQUISITION_TIMEOUT: 10 # Max time to acquire connection
       # Server performance settings
       PGRST_MAX_ROWS: 1000                 # Limit result set size
+      # Quieter logs reduce log buffer memory and CloudWatch volume; default is "info"
+      PGRST_LOG_LEVEL: warn
       # Enable schema reloading via NOTIFY
       PGRST_DB_CHANNEL_ENABLED: true
       PGRST_DB_CHANNEL: pgrst


### PR DESCRIPTION
## Summary
- PostgREST defaults to `info` log level, which emits a line for every HTTP request. Bumps to `warn` so we still see auth failures, query errors, schema reload failures, and pool exhaustion — but drop the per-request noise.
- Frees a small amount of memory in the in-process log buffer and meaningfully cuts the CloudWatch awslogs volume per tenant.

## Why this is split from the heap-cap PR
This is a different concern (operational quietness vs. memory hoarding). Splitting keeps each change independently revertable.

## Scope notes
- Originally I considered also adding a docker `healthcheck` for postgrest, but the v12 official image is `scratch`-based with no shell, so a `wget`/`curl`-style healthcheck won't run. (For reference: the wget healthcheck in `insforge/docker-compose.dokploy.yml` is likely silently broken — separate ticket worth filing.) A proper postgrest healthcheck needs either a sidecar or `PGRST_ADMIN_SERVER_PORT` exposed, which is more design work than belongs in this PR.

## Test plan
- [ ] Apply on one t4g.micro instance, confirm postgrest still boots and serves requests
- [ ] Tail CloudWatch for the postgrest stream — confirm 2xx requests no longer appear, errors still do
- [ ] Hit an unauthenticated endpoint that should fail — confirm the warn-level message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `PGRST_LOG_LEVEL` to `warn` for the PostgREST service to stop per-request info logs. This reduces CloudWatch log volume and trims in-process log buffer memory while keeping warnings and errors (auth failures, query errors, schema reload issues, pool exhaustion) visible.

<sup>Written for commit 6ebf7e497ffd121ebac7d4f53bcc765e00add2a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized logging configuration to reduce verbosity and improve resource utilization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/insforge-standalone/pull/78)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->