### PR TITLE
chore: bump default INSFORGE_OSS_VER to v2.1.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.5}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.6}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped the default `INSFORGE_OSS_VER` from v2.1.5 to v2.1.6 so new deployments pull `ghcr.io/insforge/insforge-oss` v2.1.6 by default. This keeps docker-compose installs on the latest patch.

<sup>Written for commit 89ed7813a2c4c7301cdac40f7ec0e8dd350cfecf. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/79?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated insforge service to v2.1.6

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/insforge-standalone/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->