### PR TITLE
[codex] Remove generated project admin policies

### DIFF
--- a/docker-init/db/db-init.sql
+++ b/docker-init/db/db-init.sql
@@ -6,92 +6,21 @@ CREATE ROLE anon NOLOGIN;
 CREATE ROLE authenticated NOLOGIN;
 
 -- Create project admin role for admin users
-CREATE ROLE project_admin NOLOGIN;
+CREATE ROLE project_admin NOLOGIN BYPASSRLS;
 
 GRANT USAGE ON SCHEMA public TO anon;
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO anon;
 GRANT USAGE ON SCHEMA public TO authenticated;
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO authenticated;
-GRANT USAGE ON SCHEMA public TO project_admin;
-GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO project_admin;
+GRANT ALL ON SCHEMA public TO project_admin;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO project_admin;
 
 -- Grant permissions to roles
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO anon, authenticated, project_admin;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon, authenticated, project_admin;
--- Create function to automatically create RLS policies for new tables
-CREATE OR REPLACE FUNCTION public.create_default_policies()
-RETURNS event_trigger AS $$
-DECLARE
-  obj record;
-  table_schema text;
-  table_name text;
-  has_rls boolean;
-BEGIN
-  FOR obj IN SELECT * FROM pg_event_trigger_ddl_commands() WHERE command_tag = 'CREATE TABLE'
-  LOOP
-    -- Extract schema and table name from object_identity
-    -- Handle quoted identifiers by removing quotes
-    SELECT INTO table_schema, table_name
-      split_part(obj.object_identity, '.', 1),
-      trim(both '"' from split_part(obj.object_identity, '.', 2));
-    -- Check if RLS is enabled on the table
-    SELECT INTO has_rls
-      rowsecurity
-    FROM pg_tables
-    WHERE schemaname = table_schema
-      AND tablename = table_name;
-    -- Only create policies if RLS is enabled
-    IF has_rls THEN
-      -- Create policy for project_admin role only
-      -- Users must define their own policies for anon and authenticated roles
-      EXECUTE format('CREATE POLICY "project_admin_policy" ON %s FOR ALL TO project_admin USING (true) WITH CHECK (true)', obj.object_identity);
-    END IF;
-  END LOOP;
-END;
-$$ LANGUAGE plpgsql;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO anon, authenticated;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO project_admin;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO project_admin;
 
--- Create event trigger to run the function when new tables are created
-CREATE EVENT TRIGGER create_policies_on_table_create
-  ON ddl_command_end
-  WHEN TAG IN ('CREATE TABLE')
-  EXECUTE FUNCTION public.create_default_policies();
-
--- Create function to handle RLS enablement
-CREATE OR REPLACE FUNCTION public.create_policies_after_rls()
-RETURNS event_trigger AS $$
-DECLARE
-  obj record;
-  table_schema text;
-  table_name text;
-BEGIN
-  FOR obj IN SELECT * FROM pg_event_trigger_ddl_commands() WHERE command_tag = 'ALTER TABLE'
-  LOOP
-    -- Extract schema and table name
-    -- Handle quoted identifiers by removing quotes
-    SELECT INTO table_schema, table_name
-      split_part(obj.object_identity, '.', 1),
-      trim(both '"' from split_part(obj.object_identity, '.', 2));
-    -- Check if table has RLS enabled and no policies yet
-    IF EXISTS (
-      SELECT 1 FROM pg_tables
-      WHERE schemaname = table_schema
-        AND tablename = table_name
-        AND rowsecurity = true
-    ) AND NOT EXISTS (
-      SELECT 1 FROM pg_policies
-      WHERE schemaname = table_schema
-        AND tablename = table_name
-    ) THEN
-      -- Create policy for project_admin role only
-      -- Users must define their own policies for anon and authenticated roles
-      EXECUTE format('CREATE POLICY "project_admin_policy" ON %s FOR ALL TO project_admin USING (true) WITH CHECK (true)', obj.object_identity);
-    END IF;
-  END LOOP;
-END;
-$$ LANGUAGE plpgsql;
-
--- Create event trigger for ALTER TABLE commands
-CREATE EVENT TRIGGER create_policies_on_rls_enable
-  ON ddl_command_end
-  WHEN TAG IN ('ALTER TABLE')
-  EXECUTE FUNCTION public.create_policies_after_rls();
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon, authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO project_admin;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO project_admin;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO project_admin;


### PR DESCRIPTION
## Summary
- Create `project_admin` with `BYPASSRLS` in the standalone Postgres init SQL.
- Grant `project_admin` public schema/table/sequence/function privileges and matching default privileges for future public objects.
- Remove the event triggers/functions that auto-created per-table `project_admin_policy` entries.

## Context
This keeps the EC2 standalone bundle aligned with InsForge/InsForge#1320.

## Validation
- `rg -n "project_admin_policy|create_policies_on_table_create|create_policies_on_rls_enable|create_default_policies|create_policies_after_rls"`
- `rg -n "CREATE ROLE project_admin|GRANT .*project_admin|ALTER DEFAULT PRIVILEGES.*project_admin" docker-init/db/db-init.sql`
- `git diff --check`
- `docker-compose config --quiet`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Give the `project_admin` role `BYPASSRLS` and full privileges on `public` schema objects, and remove the triggers that auto-created per-table `project_admin_policy`. This simplifies RLS handling and aligns the EC2 standalone bundle with InsForge/InsForge#1320.

- **Refactors**
  - Make `project_admin` `BYPASSRLS`.
  - Grant ALL on `public` schema, ALL on existing tables/sequences, EXECUTE on functions, and set matching default privileges.
  - Remove auto-policy functions and event triggers for table creation and RLS enablement.

<sup>Written for commit a66233e34f3eb825e803d770b88446a8f34c5fd1. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/80?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

