### PR TITLE
Bump postgres image to v15.13.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 
 services:
   postgres:
-    image: ghcr.io/insforge/postgres:v15.13.2
+    image: ghcr.io/insforge/postgres:v15.13.3
     container_name: insforge-postgres
     restart: unless-stopped
     command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}'


### PR DESCRIPTION
## Summary
- update the standalone Postgres image from ghcr.io/insforge/postgres:v15.13.2 to v15.13.3

## Validation
- docker compose config --quiet
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Postgres Docker image to `ghcr.io/insforge/postgres:v15.13.3` to pick up the latest patch release. No other changes.

<sup>Written for commit 65b3a77f16bd3c4a1c42f08a61cdd24addb6dc74. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/82?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL database service image from version 15.13.2 to 15.13.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/insforge-standalone/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->