### PR TITLE
Configure postgres policy hook

### DIFF
--- a/docker-init/db/postgresql.conf
+++ b/docker-init/db/postgresql.conf
@@ -15,7 +15,8 @@ max_wal_senders = 10
 
 # Shared preload libraries (if needed)
 # shared_preload_libraries = 'pg_stat_statements'
-shared_preload_libraries = 'pg_cron,http,pgcrypto,vector,pg_net'
+shared_preload_libraries = 'pg_cron,http,pgcrypto,vector,pg_net,insforge_pg_utils'
+insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messages,payments.checkout_sessions,payments.customer_portal_sessions'
 
 cron.database_name = 'insforge'
 


### PR DESCRIPTION
## Summary
- preload insforge_pg_utils in standalone Postgres config
- configure the managed-schema policy allowlist GUC used by the hook

## Validation
- inspected diff only; config change must be validated by restarting standalone Postgres and checking shared_preload_libraries / insforge.policy_grant_tables

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the Postgres policy hook by preloading `insforge_pg_utils` and setting the managed-schema allowlist via `insforge.policy_grant_tables`. This lets the hook grant policy access to the listed tables in standalone Postgres.

- **Migration**
  - Restart standalone Postgres to apply `shared_preload_libraries`.
  - Verify with: SHOW shared_preload_libraries; and SHOW insforge.policy_grant_tables;

<sup>Written for commit 3d39331a726fbdf74c208b310b7bc42f94b713bf. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/83?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database infrastructure configuration by expanding available libraries and extending policy management capabilities for security and operational features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/insforge-standalone/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->