### PR TITLE
chore: bump default INSFORGE_OSS_VER to v2.1.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.7}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.8}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the default `INSFORGE_OSS_VER` in `docker-compose.yml` from v2.1.7 to v2.1.8 so `docker-compose up` pulls the latest `ghcr.io/insforge/insforge-oss` image. New deployments get the latest fixes without extra env configuration.

<sup>Written for commit d50d85f78537ad291bd7e8449c1095c6e07ad657. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/84?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service container image version to v2.1.8

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/insforge-standalone/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->