### PR TITLE
chore: bump default INSFORGE_OSS_VER to v2.1.9

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.8}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.9}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
Bumps the default `INSFORGE_OSS_VER` in `docker-compose.yml` from v2.1.8 → v2.1.9.

Opened automatically by john-bot after releasing InsForge/InsForge v2.1.9.

Fresh standalone deployments will pull the new OSS image by default. Please review and merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the default `INSFORGE_OSS_VER` from v2.1.8 to v2.1.9 in `docker-compose.yml` so new deployments pull `ghcr.io/insforge/insforge-oss:v2.1.9` by default. Existing deployments are unaffected unless the env var is changed.

<sup>Written for commit c37de976eacec69b5750cd3d783b7e3045d12887. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/85?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core service version to v2.1.9.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/insforge-standalone/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->