### PR TITLE
chore: rollback default INSFORGE_OSS_VER to v2.1.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.9}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.7}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
## What

Rolls back the default `INSFORGE_OSS_VER` in `docker-compose.yml` from `v2.1.9` to `v2.1.7`.

## Why

Requested via Slack thread — revert the OSS version to v2.1.7. Users who pin their own `INSFORGE_OSS_VER` env var are unaffected; this only changes the fallback default for fresh deployments.

## Change

```diff
- image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.9}
+ image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.1.7}
```

## Test plan

- Pull the updated `docker-compose.yml` and run `docker compose up` without setting `INSFORGE_OSS_VER` — confirm the `insforge` container starts from the `v2.1.7` image.
- Set `INSFORGE_OSS_VER=v2.1.9` and confirm the override still works as expected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolled back the default `INSFORGE_OSS_VER` in `docker-compose.yml` from v2.1.9 to v2.1.7 to align with the requested OSS baseline. This only affects the fallback image for new deployments; explicit `INSFORGE_OSS_VER` values still override.

<sup>Written for commit 9bc59a489d855d436ebd8ce0f4224a3d65976657. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/86?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default container version to v2.1.7.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/insforge-standalone/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->