### PR TITLE
Update payments RLS allowlist

### DIFF
--- a/docker-init/db/postgresql.conf
+++ b/docker-init/db/postgresql.conf
@@ -16,7 +16,7 @@ max_wal_senders = 10
 # Shared preload libraries (if needed)
 # shared_preload_libraries = 'pg_stat_statements'
 shared_preload_libraries = 'pg_cron,http,pgcrypto,vector,pg_net,insforge_pg_utils'
-insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messages,payments.checkout_sessions,payments.customer_portal_sessions'
+insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messages,payments.stripe_checkout_sessions,payments.stripe_customer_portal_sessions,payments.razorpay_orders,payments.razorpay_subscriptions'
 
 cron.database_name = 'insforge'
 


### PR DESCRIPTION
## Summary
- replace legacy generic payments RLS allowlist entries with provider-specific runtime tables
- allow project_admin policy management for Stripe Checkout/Portal and Razorpay Orders/Subscriptions

## Why
The payments schema now uses provider-specific runtime authorization tables. Cloud project provisioning reads this standalone postgresql.conf, so new projects need the updated allowlist.

## Validation
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update payments RLS allowlist by switching `insforge.policy_grant_tables` to provider-specific tables: `payments.stripe_checkout_sessions`, `payments.stripe_customer_portal_sessions`, `payments.razorpay_orders`, `payments.razorpay_subscriptions`. This replaces legacy entries and enables project_admin policy management for Stripe Checkout/Portal and Razorpay Orders/Subscriptions in newly provisioned projects.

<sup>Written for commit b8516a309284e23f175c6589b6db0da677f441de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

