### PR TITLE
Devel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.1-deno2}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.1-deno3}
     working_dir: /app
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.0}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.1-deno}
     working_dir: /app
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,9 +126,12 @@ services:
       - POSTGREST_BASE_URL=http://postgrest:3000
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
       - CLOUD_API_HOST=${CLOUD_API_HOST}
-      # Deno Subhosting Configuration
+      # Deno Subhosting Configuration (legacy, read by OSS < v2 Deno Deploy migration)
       - DENO_SUBHOSTING_TOKEN=${DENO_SUBHOSTING_TOKEN:-}
       - DENO_SUBHOSTING_ORG_ID=${DENO_SUBHOSTING_ORG_ID:-}
+      # Deno Deploy Configuration (read by OSS >= v2 Deno Deploy migration)
+      - DENO_DEPLOY_TOKEN=${DENO_DEPLOY_TOKEN:-}
+      - DENO_DEPLOY_ORG_ID=${DENO_DEPLOY_ORG_ID:-}
       # OAuth Configuration
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.1-deno}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.1-deno2}
     working_dir: /app
     restart: unless-stopped
     deploy:
@@ -126,8 +126,6 @@ services:
       - POSTGREST_BASE_URL=http://postgrest:3000
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
       - CLOUD_API_HOST=${CLOUD_API_HOST}
-      # Deno Runtime URL
-      - DENO_RUNTIME_URL=http://deno:7133
       # Deno Subhosting Configuration
       - DENO_SUBHOSTING_TOKEN=${DENO_SUBHOSTING_TOKEN:-}
       - DENO_SUBHOSTING_ORG_ID=${DENO_SUBHOSTING_ORG_ID:-}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps the default `insforge` OSS image to `v2.2.1-deno3` and adds Deno Deploy env vars to support the v2 migration. Removes the local `DENO_RUNTIME_URL` and clarifies legacy subhosting envs.

- **Migration**
  - Add `DENO_DEPLOY_TOKEN` and `DENO_DEPLOY_ORG_ID` to your environment.
  - Remove `DENO_RUNTIME_URL`. Keep `DENO_SUBHOSTING_TOKEN` and `DENO_SUBHOSTING_ORG_ID` only if using pre-v2 images.

<sup>Written for commit 3358d78462b3d1c45c2ed8460977ccd31df2a472. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated hosting infrastructure configuration to support new deployment authentication variables for Deno hosting services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->