### PR TITLE
chore: bump default INSFORGE_OSS_VER to v2.2.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.2}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.3}
     working_dir: /app
     restart: unless-stopped
     deploy:

--- a/docker-init/db/postgresql.conf
+++ b/docker-init/db/postgresql.conf
@@ -18,6 +18,11 @@ max_wal_senders = 10
 shared_preload_libraries = 'pg_cron,http,pgcrypto,vector,pg_net,insforge_pg_utils'
 insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messages,payments.stripe_checkout_sessions,payments.stripe_customer_portal_sessions,payments.razorpay_orders,payments.razorpay_subscriptions'
 
+# InsForge-internal schemas kept off the PostgREST data API (deny-list for
+# custom-schema exposure; see migration 056). Every other non-internal schema
+# is auto-exposed. Keep in sync with the migration's fallback list.
+insforge.internal_schemas = 'ai,auth,compute,deployments,email,functions,memory,payments,realtime,schedules,storage,system'
+
 cron.database_name = 'insforge'
 
 # Memory tuning for low-memory environments (< 1GB total RAM)


### PR DESCRIPTION
Bumps the default `INSFORGE_OSS_VER` in `docker-compose.yml` from v2.2.2 → v2.2.3.

Opened automatically by john-bot after releasing InsForge/InsForge v2.2.3.

Fresh standalone deployments will pull the new OSS image by default. Please review and merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the default `INSFORGE_OSS_VER` in `docker-compose.yml` to v2.2.3. Also declares `insforge.internal_schemas` in `docker-init/db/postgresql.conf` to support migration 056, ensuring fresh deployments pull the v2.2.3 image and use the canonical internal schema deny list for PostgREST.

<sup>Written for commit ae1281f7e34f5a21b6bd6df9c702ffec86722d8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the app’s default container image to the latest patch release.
* **Security / Configuration**
  * Added a PostgreSQL setting to restrict PostgREST from exposing selected internal schemas via its custom-schema interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->