### PR TITLE
chore: bump default INSFORGE_OSS_VER to v2.2.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.3}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.4}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump the default Insforge OSS image to v2.2.4 in docker-compose to pick up the latest fixes. Deployments that don’t set `INSFORGE_OSS_VER` will now pull `ghcr.io/insforge/insforge-oss:v2.2.4`.

<sup>Written for commit 80b9dc71c234bd47cf966c10f1786f293c319499. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application container to the latest available version, which may include general improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->