### PR TITLE
chore: bump default INSFORGE_OSS_VER to v2.2.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.4}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.5}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
Bumps the default `INSFORGE_OSS_VER` in `docker-compose.yml` from v2.2.4 → v2.2.5.

Opened automatically by john-bot after releasing InsForge/InsForge v2.2.5.

Fresh standalone deployments will pull the new OSS image by default. Please review and merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the default `INSFORGE_OSS_VER` in `docker-compose.yml` from v2.2.4 to v2.2.5. New deployments will use the latest OSS image by default; existing overrides are unaffected.

<sup>Written for commit 21d9f041584c7eaa4d24c1cc06ddce4222d6871b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default container version used for the app when no version is specified, bringing the bundled OSS release to a newer build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->