### PR TITLE
Scale PostgREST pool + Postgres max_connections by instance RAM

### DIFF
--- a/auto-scale-memory.sh
+++ b/auto-scale-memory.sh
@@ -64,6 +64,22 @@ POSTGREST_MEM=$(awk "BEGIN {printf \"%.0f\", $POSTGREST_BASE * $SCALE_FACTOR}")
 POSTGREST_RTS_HEAP=$(( POSTGREST_MEM - 20 ))
 if [ "$POSTGREST_RTS_HEAP" -lt 20 ]; then POSTGREST_RTS_HEAP=20; fi
 
+# --- Scale PostgREST pool + Postgres max_connections with instance RAM ----------
+# Each Postgres backend costs ~5-10MB, so these are BOUNDED per RAM tier (NOT scaled
+# linearly with the memory factor, which would OOM Postgres on large instances).
+# PGRST_DB_POOL is kept at ~55-60% of max_connections, leaving headroom for the app,
+# admin, and direct DB connections. Fixes both nano over-pooling (OOM risk) and
+# medium/xl under-pooling (PGRST003 "timed out acquiring connection from pool").
+if   [ "$TOTAL_MEM" -ge 30000 ]; then PG_MAX_CONNECTIONS=700; PGRST_DB_POOL=450   # 2xl ~32G
+elif [ "$TOTAL_MEM" -ge 15000 ]; then PG_MAX_CONNECTIONS=400; PGRST_DB_POOL=250   # xl ~16G
+elif [ "$TOTAL_MEM" -ge 7500  ]; then PG_MAX_CONNECTIONS=250; PGRST_DB_POOL=150   # large ~8G
+elif [ "$TOTAL_MEM" -ge 3500  ]; then PG_MAX_CONNECTIONS=150; PGRST_DB_POOL=90    # medium ~4G
+elif [ "$TOTAL_MEM" -ge 1800  ]; then PG_MAX_CONNECTIONS=80;  PGRST_DB_POOL=45    # small ~2G
+elif [ "$TOTAL_MEM" -ge 900   ]; then PG_MAX_CONNECTIONS=50;  PGRST_DB_POOL=25    # micro ~1G
+else                                  PG_MAX_CONNECTIONS=30;  PGRST_DB_POOL=15    # nano ~0.5G
+fi
+echo "Connection scaling: PGRST_DB_POOL=${PGRST_DB_POOL}, PG_MAX_CONNECTIONS=${PG_MAX_CONNECTIONS} (RAM ${TOTAL_MEM}MB)"
+
 # Verify total doesn't exceed usable memory
 TOTAL_ALLOCATED=$(( POSTGRES_MEM + POSTGREST_MEM + INSFORGE_MEM ))
 
@@ -83,7 +99,7 @@ ENV_FILE=".env"
 cp "$ENV_FILE" "${ENV_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
 
 # Remove existing memory settings if present
-sed -i.tmp '/^POSTGRES_MEMORY=/d; /^POSTGREST_MEMORY=/d; /^POSTGREST_RTS_HEAP=/d; /^INSFORGE_MEMORY=/d; /^DENO_MEMORY=/d; /^VECTOR_MEMORY=/d; /^NODE_EXPORTER_MEMORY=/d; /^# Auto-generated memory limits/d; /^# Total system memory:/d; /^# Usable memory:/d; /^# Scaling factor:/d' "$ENV_FILE"
+sed -i.tmp '/^POSTGRES_MEMORY=/d; /^POSTGREST_MEMORY=/d; /^PGRST_DB_POOL=/d; /^PG_MAX_CONNECTIONS=/d; /^POSTGREST_RTS_HEAP=/d; /^INSFORGE_MEMORY=/d; /^DENO_MEMORY=/d; /^VECTOR_MEMORY=/d; /^NODE_EXPORTER_MEMORY=/d; /^# Auto-generated memory limits/d; /^# Total system memory:/d; /^# Usable memory:/d; /^# Scaling factor:/d' "$ENV_FILE"
 rm -f "${ENV_FILE}.tmp"
 
 # Append new memory settings
@@ -97,6 +113,8 @@ POSTGRES_MEMORY=${POSTGRES_MEM}M
 POSTGREST_MEMORY=${POSTGREST_MEM}M
 POSTGREST_RTS_HEAP=${POSTGREST_RTS_HEAP}M
 INSFORGE_MEMORY=${INSFORGE_MEM}M
+PGRST_DB_POOL=${PGRST_DB_POOL}
+PG_MAX_CONNECTIONS=${PG_MAX_CONNECTIONS}
 EOF
 
 echo "Memory configuration updated in ${ENV_FILE}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: ghcr.io/insforge/postgres:v15.13.4
     container_name: insforge-postgres
     restart: unless-stopped
-    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}'
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c max_connections=${PG_MAX_CONNECTIONS:-100} -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}'
     deploy:
       resources:
         limits:
@@ -66,7 +66,7 @@ services:
       PGRST_DB_ANON_ROLE: anon
       PGRST_JWT_SECRET: ${JWT_SECRET}
       # Connection pool settings (CRITICAL for stability)
-      PGRST_DB_POOL: 30                    # Max connections in pool (default: 10)
+      PGRST_DB_POOL: ${PGRST_DB_POOL:-30}                    # Max connections in pool (default: 10)
       PGRST_DB_POOL_TIMEOUT: 10            # Seconds to wait for connection (default: 10)
       PGRST_DB_POOL_ACQUISITION_TIMEOUT: 10 # Max time to acquire connection
       # Server performance settings


### PR DESCRIPTION
## What
 Scale PostgREST `PGRST_DB_POOL` and Postgres `max_connections` with the instance's RAM (was hardcoded PGRST_DB_POOL=30 / static max_connections=60). `auto-scale-memory.sh` (run on every instance via default.sh) derives both from TOTAL_MEM and writes to .env; compose consumes them.

| tier | RAM | max_connections | PGRST_DB_POOL |
|---|---|---|---|
| nano |0.5G|30|15|
| micro |1G|50|25|
| small |2G|80|45|
| medium |4G|150|90|
| large |8G|250|150|
| xl |16G|400|250|
| 2xl |32G|700|450|

## Why
 Fixed pool is wrong both ways: too big for nano (~OOM) and too small for medium/xl (Palise 6cuj5i5e hit PGRST003 'timed out acquiring connection from pool' -> 504 lockouts). Pool ~=55-60% of max_connections leaves headroom.

## Review notes
- Bounded per-tier (NOT linear with mem factor).
- Backward-safe: compose defaults (:-30, :-100) preserve current behavior if env unset.
- Needs eng review + staged per-tier test before merge; a wrong max_connections could OOM Postgres on small tiers. Values are a tunable starting point.

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scale the PostgREST connection pool and Postgres max_connections based on instance RAM to prevent OOM on small tiers and reduce pool timeouts on larger tiers. This right-sizes capacity across tiers and adds safe headroom.

- **New Features**
  - Added bounded per-RAM tier scaling in `auto-scale-memory.sh` to set `PG_MAX_CONNECTIONS` and `PGRST_DB_POOL` (pool ~55–60% of max).
  - Script writes values to `.env`; executed on every instance via `default.sh`.
  - `docker-compose.yml` now consumes `PG_MAX_CONNECTIONS` and `PGRST_DB_POOL` with safe defaults to remain backward compatible.

<sup>Written for commit ac9e345dbf47997b968f3444d6a5ab6d38432a61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic database connection scaling based on available system memory.
  * PostgreSQL and PostgREST now use dynamically calculated connection limits, with configurable defaults.

* **Bug Fixes**
  * Existing autogenerated connection settings are replaced cleanly when memory configuration is updated.
  * Database service startup now applies the configured connection limit consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->