### PR TITLE
Point standalone at insforge-oss v2.2.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.6}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.7}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
Updates the default `insforge` service image tag in docker-compose.yml from `v2.2.6` to `v2.2.7`, so standalone deployments pick up the newly published [InsForge v2.2.7 release](https://github.com/InsForge/InsForge/releases/tag/v2.2.7) by default (deployments can still override via `INSFORGE_OSS_VER`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the default `ghcr.io/insforge/insforge-oss` image tag in `docker-compose.yml` from `v2.2.6` to `v2.2.7`, so standalone deployments use the latest release by default. You can still override the version via `INSFORGE_OSS_VER`.

<sup>Written for commit a5fe20318a5823264b007ee7d7a28f6df94d838c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the InsForge service to version 2.2.7 for the latest available improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->