### PR TITLE
feat: align backend POSTGREST_MAX_SOCKETS with PGRST_DB_POOL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - POSTGREST_BASE_URL=http://postgrest:3000
+      - POSTGREST_MAX_SOCKETS=${PGRST_DB_POOL:-30}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
       - CLOUD_API_HOST=${CLOUD_API_HOST}
       # Deno Subhosting Configuration (legacy, read by OSS < v2 Deno Deploy migration)


### PR DESCRIPTION
## Summary

Passes `POSTGREST_MAX_SOCKETS` to the insforge backend service, sourced from the same `PGRST_DB_POOL` variable (default 30) that sizes PostgREST's database pool.

This keeps the backend's HTTP agent concurrency toward PostgREST always equal to the connection pool it drains into — one variable tunes both sides per instance size. With the two aligned, overload queues inside PostgREST (bounded by `PGRST_DB_POOL_ACQUISITION_TIMEOUT`, surfacing as a clean 504 that the backend never retries) instead of piling up in the backend's HTTP agent queue, where queue wait counts against the axios timeout and used to surface as retried `ECONNABORTED` timeouts.

## Compatibility

No-op until `INSFORGE_OSS_VER` points at a backend image containing InsForge/InsForge#1792, which introduces the `POSTGREST_MAX_SOCKETS` setting. The current default (`v2.2.6`) simply ignores the variable and keeps its built-in pool size, so this can merge ahead of the backend release.

## Connection budget check

Postgres runs with `max_connections=${PG_MAX_CONNECTIONS:-100}`; PostgREST pool (30) + backend's direct pg pool (20) = 50, leaving ample headroom at the defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns backend HTTP concurrency with PostgREST by passing `POSTGREST_MAX_SOCKETS=${PGRST_DB_POOL:-30}` in `docker-compose.yml`. Overload now queues in PostgREST (clean 504 via `PGRST_DB_POOL_ACQUISITION_TIMEOUT`) instead of timing out in the backend’s HTTP client.

- **Migration**
  - No action required; older backend images ignore `POSTGREST_MAX_SOCKETS`.
  - Becomes effective when `INSFORGE_OSS_VER` targets a backend that supports `POSTGREST_MAX_SOCKETS`.

<sup>Written for commit 0aa13c61e66d8126bf50b538d2426bbbf5a24717. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

