### PR TITLE
feat: enable slow-query observability in postgres

### DIFF
--- a/docker-init/db/db-init.sql
+++ b/docker-init/db/db-init.sql
@@ -1,4 +1,8 @@
 -- init.sql
+-- Per-statement execution stats for slow-query observability
+-- (library is preloaded via shared_preload_libraries in postgresql.conf)
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
 -- Create role for anonymous user
 CREATE ROLE anon NOLOGIN;
 

--- a/docker-init/db/db-init.sql
+++ b/docker-init/db/db-init.sql
@@ -1,7 +1,13 @@
 -- init.sql
--- Per-statement execution stats for slow-query observability
--- (library is preloaded via shared_preload_libraries in postgresql.conf)
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+-- Per-statement execution stats for slow-query observability. Lives in a
+-- dedicated schema (on the insforge.internal_schemas deny-list, and with no
+-- USAGE grant for API roles) so the view is never reachable through the
+-- PostgREST data API — in public it would be swept up by the blanket GRANT
+-- below and auto-exposed to anon. Library is preloaded via
+-- shared_preload_libraries in postgresql.conf. Query it as superuser:
+--   SELECT * FROM monitoring.pg_stat_statements;
+CREATE SCHEMA IF NOT EXISTS monitoring;
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA monitoring;
 
 -- Create role for anonymous user
 CREATE ROLE anon NOLOGIN;

--- a/docker-init/db/postgresql.conf
+++ b/docker-init/db/postgresql.conf
@@ -13,9 +13,8 @@ max_replication_slots = 10
 # Set max WAL senders
 max_wal_senders = 10
 
-# Shared preload libraries (if needed)
-# shared_preload_libraries = 'pg_stat_statements'
-shared_preload_libraries = 'pg_cron,http,pgcrypto,vector,pg_net,insforge_pg_utils'
+# Shared preload libraries
+shared_preload_libraries = 'pg_cron,http,pgcrypto,vector,pg_net,insforge_pg_utils,pg_stat_statements'
 insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messages,payments.stripe_checkout_sessions,payments.stripe_customer_portal_sessions,payments.razorpay_orders,payments.razorpay_subscriptions'
 
 # InsForge-internal schemas kept off the PostgREST data API (deny-list for
@@ -36,3 +35,6 @@ max_connections = 60
 
 # WAL settings for stability
 wal_buffers = 2MB
+
+# Slow-query logging: statements slower than 500ms go to the postgres log
+log_min_duration_statement = 500

--- a/docker-init/db/postgresql.conf
+++ b/docker-init/db/postgresql.conf
@@ -19,8 +19,10 @@ insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messa
 
 # InsForge-internal schemas kept off the PostgREST data API (deny-list for
 # custom-schema exposure; see migration 056). Every other non-internal schema
-# is auto-exposed. Keep in sync with the migration's fallback list.
-insforge.internal_schemas = 'ai,auth,compute,deployments,email,functions,memory,payments,realtime,schedules,storage,system'
+# is auto-exposed. Keep in sync with the migration's fallback list
+# ('monitoring' is standalone-only — created in db-init.sql, intentionally
+# absent from the migration fallback).
+insforge.internal_schemas = 'ai,auth,compute,deployments,email,functions,memory,monitoring,payments,realtime,schedules,storage,system'
 
 cron.database_name = 'insforge'
 
@@ -36,5 +38,9 @@ max_connections = 60
 # WAL settings for stability
 wal_buffers = 2MB
 
-# Slow-query logging: statements slower than 500ms go to the postgres log
+# Slow-query logging: statements slower than 500ms are logged with their full
+# SQL text, inline literals included — treat the postgres log stream (and the
+# CloudWatch group it ships to) as sensitive, access via IAM only. If volume
+# gets noisy on small instances, raise this threshold or switch to sampling
+# (log_min_duration_sample + log_statement_sample_rate).
 log_min_duration_statement = 500


### PR DESCRIPTION
## Summary

Enable slow-query observability for newly started projects:

- Preload `pg_stat_statements` in `shared_preload_libraries` and create the extension on first init in a dedicated **`monitoring` schema**, so per-statement execution stats are queryable out of the box on fresh instances: `SELECT * FROM monitoring.pg_stat_statements;` (superuser)
- The `monitoring` schema is on the `insforge.internal_schemas` deny-list and API roles (`anon`/`authenticated`/`project_admin`) get no `USAGE` on it, so the stats view is **not** reachable through the PostgREST data API
- Set `log_min_duration_statement = 500` so any statement slower than 500ms is logged with its full SQL text (visible via `docker logs insforge-postgres` and the CloudWatch `*-postgres-vector` stream)

## Verification

Booted a throwaway container from `ghcr.io/insforge/postgres:v15.13.4` with the new conf + init script:

- Image ships `pg_stat_statements.so` for the running server (PG 15.18 at `/usr/lib/postgresql/15/lib/`); boots cleanly with the preload
- Extension lands in `monitoring`; superuser can query the view
- `SET ROLE anon; SELECT * FROM monitoring.pg_stat_statements` → `permission denied for schema monitoring`
- `SELECT pg_sleep(0.6)` → `LOG: duration: 607.274 ms statement: ...`

## Notes

- Only affects **new** deployments: `db-init.sql` runs on first volume init, and the preload change requires a postgres restart. Existing instances need a manual `docker compose restart postgres` + `CREATE SCHEMA IF NOT EXISTS monitoring; CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA monitoring;`
- Slow-query logs include inline literals, so the postgres log stream / CloudWatch group should be treated as sensitive (IAM-gated). If the 500ms threshold proves noisy on small instances, raise it or switch to sampling (`log_min_duration_sample` + `log_statement_sample_rate`) — documented in `postgresql.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)