### PR TITLE
chore: bump default insforge-oss version to v2.2.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   insforge:
     container_name: insforge
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.7}
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.8}
     working_dir: /app
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
## What

Bump the default `insforge-oss` image tag from `v2.2.7` to `v2.2.8` in `docker-compose.yml`:

```yaml
image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VER:-v2.2.8}
```

## Why

`v2.2.8` is the new default OSS image version. The `${INSFORGE_OSS_VER:-...}` fallback in `docker-compose.yml:96` is the only place this default is hardcoded — nothing in `.env` or `README` references the version, confirmed by a repo-wide grep for `v2.2.7` / `INSFORGE_OSS_VER` (single hit). Deployments that don't set `INSFORGE_OSS_VER` explicitly will now pull `v2.2.8`.

## Test plan

- `git diff` shows exactly the one-line fallback change.
- `docker-compose.yml` still parses as valid YAML.
- Behavior is unchanged for anyone who sets `INSFORGE_OSS_VER` explicitly (only the fallback is affected).

Closes #104


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump the default `insforge-oss` image tag in `docker-compose.yml` from v2.2.7 to v2.2.8 so deployments without `INSFORGE_OSS_VER` pull the latest OSS release. No change for setups that set `INSFORGE_OSS_VER` explicitly.

<sup>Written for commit fe5fffe2f05e89950af5ecf5cd64689252d9b13f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default InsForge service image to version 2.2.8.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->