### PR TITLE
INS-545 feat: auto-scale container CPU limits with instance size

### DIFF
--- a/auto-scale-memory.sh
+++ b/auto-scale-memory.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Auto-scale Docker Compose memory limits based on total system memory
-# This script maintains the current memory ratio between services
+# Auto-scale Docker Compose memory and CPU limits based on total system resources
+# This script maintains the current memory/CPU ratio between services
 
 set -e
 
@@ -10,19 +10,26 @@ POSTGRES_BASE=150
 POSTGREST_BASE=50
 INSFORGE_BASE=150
 
+# Current CPU configuration (in cores, matches docker-compose.yml defaults)
+POSTGRES_CPUS_BASE=0.5
+POSTGREST_CPUS_BASE=0.3
+INSFORGE_CPUS_BASE=0.5
+
 # Total base memory
 TOTAL_BASE=$(( POSTGRES_BASE + POSTGREST_BASE + INSFORGE_BASE ))
 echo "Base total memory: ${TOTAL_BASE}MB"
 
-# Get total system memory (in MB)
+# Get total system memory (in MB) and CPU core count
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Linux - get total memory
     TOTAL_MEM=$(free -m | awk 'NR==2 {print $2}')
-    echo "Total system memory on Linux: ${TOTAL_MEM}MB"
+    TOTAL_CPUS=$(nproc)
+    echo "Total system memory on Linux: ${TOTAL_MEM}MB, CPUs: ${TOTAL_CPUS}"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     # macOS - get total memory
     TOTAL_MEM=$(sysctl -n hw.memsize | awk '{print $1/1024/1024}')
-    echo "Total system memory on macOS: ${TOTAL_MEM}MB"
+    TOTAL_CPUS=$(sysctl -n hw.ncpu)
+    echo "Total system memory on macOS: ${TOTAL_MEM}MB, CPUs: ${TOTAL_CPUS}"
 else
     echo "Unsupported OS: $OSTYPE"
     exit 1
@@ -80,14 +87,31 @@ else                                  PG_MAX_CONNECTIONS=30;  PGRST_DB_POOL=15  
 fi
 echo "Connection scaling: PGRST_DB_POOL=${PGRST_DB_POOL}, PG_MAX_CONNECTIONS=${PG_MAX_CONNECTIONS} (RAM ${TOTAL_MEM}MB)"
 
+# --- Scale CPU limits with instance core count ----------------------------------
+# Base config totals 1.3 cpus (0.5 + 0.3 + 0.5), sized for the smallest instances.
+# Reserve 0.3 cores for the host (dockerd, log drivers, ssh), split the rest in the
+# same ratio as the base config. Floor at 1.0 so small instances keep the base
+# limits (cpus is a cap, not an allocation, so mild overcommit there is fine).
+CPU_TOTAL_BASE=$(awk "BEGIN {printf \"%.2f\", $POSTGRES_CPUS_BASE + $POSTGREST_CPUS_BASE + $INSFORGE_CPUS_BASE}")
+RESERVED_CPU=0.3
+USABLE_CPUS=$(awk "BEGIN {printf \"%.2f\", $TOTAL_CPUS - $RESERVED_CPU}")
+CPU_SCALE_FACTOR=$(awk "BEGIN {printf \"%.4f\", $USABLE_CPUS / $CPU_TOTAL_BASE}")
+if (( $(awk "BEGIN {print ($CPU_SCALE_FACTOR < 1.0)}") )); then
+    CPU_SCALE_FACTOR=1.0000
+fi
+POSTGRES_CPUS=$(awk "BEGIN {printf \"%.2f\", $POSTGRES_CPUS_BASE * $CPU_SCALE_FACTOR}")
+POSTGREST_CPUS=$(awk "BEGIN {printf \"%.2f\", $POSTGREST_CPUS_BASE * $CPU_SCALE_FACTOR}")
+INSFORGE_CPUS=$(awk "BEGIN {printf \"%.2f\", $INSFORGE_CPUS_BASE * $CPU_SCALE_FACTOR}")
+echo "CPU scaling: factor ${CPU_SCALE_FACTOR} (${TOTAL_CPUS} cores, ${RESERVED_CPU} reserved)"
+
 # Verify total doesn't exceed usable memory
 TOTAL_ALLOCATED=$(( POSTGRES_MEM + POSTGREST_MEM + INSFORGE_MEM ))
 
 echo ""
-echo "=== Calculated Memory Allocation ==="
-echo "postgres:      ${POSTGRES_MEM}MB (base: ${POSTGRES_BASE}MB)"
-echo "postgrest:     ${POSTGREST_MEM}MB (base: ${POSTGREST_BASE}MB, GHC heap cap: ${POSTGREST_RTS_HEAP}M)"
-echo "insforge:      ${INSFORGE_MEM}MB (base: ${INSFORGE_BASE}MB)"
+echo "=== Calculated Resource Allocation ==="
+echo "postgres:      ${POSTGRES_MEM}MB, ${POSTGRES_CPUS} cpus (base: ${POSTGRES_BASE}MB, ${POSTGRES_CPUS_BASE} cpus)"
+echo "postgrest:     ${POSTGREST_MEM}MB, ${POSTGREST_CPUS} cpus (base: ${POSTGREST_BASE}MB, ${POSTGREST_CPUS_BASE} cpus, GHC heap cap: ${POSTGREST_RTS_HEAP}M)"
+echo "insforge:      ${INSFORGE_MEM}MB, ${INSFORGE_CPUS} cpus (base: ${INSFORGE_BASE}MB, ${INSFORGE_CPUS_BASE} cpus)"
 echo "---"
 echo "Total allocated: ${TOTAL_ALLOCATED}MB / ${USABLE_MEM}MB usable"
 echo ""
@@ -99,25 +123,30 @@ ENV_FILE=".env"
 cp "$ENV_FILE" "${ENV_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
 
 # Remove existing memory settings if present
-sed -i.tmp '/^POSTGRES_MEMORY=/d; /^POSTGREST_MEMORY=/d; /^PGRST_DB_POOL=/d; /^PG_MAX_CONNECTIONS=/d; /^POSTGREST_RTS_HEAP=/d; /^INSFORGE_MEMORY=/d; /^DENO_MEMORY=/d; /^VECTOR_MEMORY=/d; /^NODE_EXPORTER_MEMORY=/d; /^# Auto-generated memory limits/d; /^# Total system memory:/d; /^# Usable memory:/d; /^# Scaling factor:/d' "$ENV_FILE"
+sed -i.tmp '/^POSTGRES_MEMORY=/d; /^POSTGREST_MEMORY=/d; /^PGRST_DB_POOL=/d; /^PG_MAX_CONNECTIONS=/d; /^POSTGREST_RTS_HEAP=/d; /^INSFORGE_MEMORY=/d; /^POSTGRES_CPUS=/d; /^POSTGREST_CPUS=/d; /^INSFORGE_CPUS=/d; /^DENO_MEMORY=/d; /^VECTOR_MEMORY=/d; /^NODE_EXPORTER_MEMORY=/d; /^# Auto-generated memory limits/d; /^# Auto-generated resource limits/d; /^# Total system memory:/d; /^# Total CPUs:/d; /^# Usable memory:/d; /^# Scaling factor:/d; /^# CPU scaling factor:/d' "$ENV_FILE"
 rm -f "${ENV_FILE}.tmp"
 
-# Append new memory settings
+# Append new resource settings
 cat >> "$ENV_FILE" << EOF
 
-# Auto-generated memory limits - $(date)
+# Auto-generated resource limits - $(date)
 # Total system memory: ${AVAILABLE_MEM}MB
+# Total CPUs: ${TOTAL_CPUS} (${RESERVED_CPU} reserved for host)
 # Usable memory: ${USABLE_MEM}MB (after ${RESERVED_MEM}MB system reservation)
 # Scaling factor: ${SCALE_FACTOR}
+# CPU scaling factor: ${CPU_SCALE_FACTOR}
 POSTGRES_MEMORY=${POSTGRES_MEM}M
 POSTGREST_MEMORY=${POSTGREST_MEM}M
 POSTGREST_RTS_HEAP=${POSTGREST_RTS_HEAP}M
 INSFORGE_MEMORY=${INSFORGE_MEM}M
+POSTGRES_CPUS=${POSTGRES_CPUS}
+POSTGREST_CPUS=${POSTGREST_CPUS}
+INSFORGE_CPUS=${INSFORGE_CPUS}
 PGRST_DB_POOL=${PGRST_DB_POOL}
 PG_MAX_CONNECTIONS=${PG_MAX_CONNECTIONS}
 EOF
 
-echo "Memory configuration updated in ${ENV_FILE}"
+echo "Resource configuration updated in ${ENV_FILE}"
 echo "Backup saved to ${ENV_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
 echo ""
 echo "To apply these settings, restart services:"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       resources:
         limits:
           memory: ${POSTGRES_MEMORY:-150M}
-          cpus: '0.5'
+          cpus: '${POSTGRES_CPUS:-0.5}'
         reservations:
           memory: 30M
     environment:
@@ -56,7 +56,7 @@ services:
       resources:
         limits:
           memory: ${POSTGREST_MEMORY:-50M}
-          cpus: '0.3'
+          cpus: '${POSTGREST_CPUS:-0.3}'
         reservations:
           memory: 20M
     environment:
@@ -100,7 +100,7 @@ services:
       resources:
         limits:
           memory: ${INSFORGE_MEMORY:-150M}
-          cpus: '0.5'
+          cpus: '${INSFORGE_CPUS:-0.5}'
         reservations:
           memory: 50M
     depends_on:


### PR DESCRIPTION
## Summary

CPU limits in `docker-compose.yml` were hardcoded (`0.5`/`0.3`/`0.5`) regardless of EC2 instance type, so upgrading an instance never gave containers more CPU. This PR makes CPU limits scale with the host core count, the same way memory limits already do.

- **docker-compose.yml**: `cpus` for postgres/postgrest/insforge is now `${POSTGRES_CPUS:-0.5}` / `${POSTGREST_CPUS:-0.3}` / `${INSFORGE_CPUS:-0.5}` — defaults match the old hardcoded values, so nothing changes until the script is run.
- **auto-scale-memory.sh**: detects core count (`nproc` / `sysctl -n hw.ncpu`), reserves 0.3 cores for the host (dockerd, log drivers, ssh), splits the rest in the base 0.5:0.3:0.5 ratio, and writes the values to `.env`. Scale factor is floored at 1.0 so small instances keep the base limits (`cpus` is a cap, so the mild overcommit there is fine).

## Resulting limits by instance size

| vCPUs | postgres | postgrest | insforge | total |
|---|---|---|---|---|
| 1–2 (nano–large) | 0.50–0.65 | 0.30–0.39 | 0.50–0.65 | 1.3–1.7 |
| 4 (xlarge) | 1.42 | 0.85 | 1.42 | 3.7 |
| 8 (2xlarge) | 2.96 | 1.78 | 2.96 | 7.7 |

## Testing

- Ran the script against a dummy `.env` (10-core host): factor 7.46, limits 3.73/2.24/3.73, values written correctly.
- Ran it twice: `sed` cleanup keeps exactly one copy of each variable.
- `docker compose config`: resolves the new vars when set, falls back to 0.5/0.3/0.5 when unset.

Existing deployments need `auto-scale-memory.sh` re-run + service restart to pick up the new CPU limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Container CPU limits now scale with the host’s vCPU count. `docker-compose.yml` uses `POSTGRES_CPUS`, `POSTGREST_CPUS`, and `INSFORGE_CPUS` with defaults, and `auto-scale-memory.sh` computes them alongside memory.

- **New Features**
  - Detect core count (`nproc`/`sysctl -n hw.ncpu`) and reserve 0.3 cores for the host.
  - Scale CPU caps in the 0.5:0.3:0.5 ratio; floor the factor at 1.0.
  - Write computed limits to `.env` and print a “Calculated Resource Allocation” summary.

- **Migration**
  - Run `auto-scale-memory.sh`, then restart services to apply new CPU limits.
  - If vars are unset, defaults stay `0.5`/`0.3`/`0.5`.

<sup>Written for commit e0eb68f8877dd64a2558ece1977fd21177e92ff0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic CPU scaling alongside memory scaling based on available system resources.
  - Docker services now receive configurable CPU limits with sensible defaults.
  - Generated environment settings now include CPU allocations, scaling details, and reserved host resources.

- **Improvements**
  - Resource allocation output now displays both memory and CPU limits.
  - Existing memory scaling and database connection settings remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->