### PR TITLE
fix: drop hard CPU caps; equal PostgREST memory share on ≥2GB instances

### DIFF
--- a/auto-scale-memory.sh
+++ b/auto-scale-memory.sh
@@ -1,23 +1,17 @@
 #!/bin/bash
 
-# Auto-scale Docker Compose memory and CPU limits based on total system resources
-# This script maintains the current memory/CPU ratio between services
+# Auto-scale Docker Compose memory limits based on total system memory.
+# CPU is deliberately NOT capped: these are single-tenant hosts, so hard CPU
+# quotas only stop a container from bursting into idle cores (a 0.3-cpu cap
+# on postgrest stalled requests under load while the host sat at load 0.01).
+# Under contention the kernel's default equal cpu.weight arbitrates.
 
 set -e
 
-# Current memory configuration (in MB)
+# Current memory configuration (in MB). POSTGREST_BASE is tier-dependent and
+# set once total memory is known.
 POSTGRES_BASE=150
-POSTGREST_BASE=50
 INSFORGE_BASE=150
-
-# Current CPU configuration (in cores, matches docker-compose.yml defaults)
-POSTGRES_CPUS_BASE=0.5
-POSTGREST_CPUS_BASE=0.3
-INSFORGE_CPUS_BASE=0.5
-
-# Total base memory
-TOTAL_BASE=$(( POSTGRES_BASE + POSTGREST_BASE + INSFORGE_BASE ))
-echo "Base total memory: ${TOTAL_BASE}MB"
 
 # Get total system memory (in MB) and CPU core count
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
@@ -34,6 +28,21 @@ else
     echo "Unsupported OS: $OSTYPE"
     exit 1
 fi
+
+# PostgREST's share: an equal third on instances with room for it. The legacy
+# 150:50:150 split starved postgrest exactly where load is highest — a 4GB
+# medium gave it 544MB against a 90-connection pool, with its heap grazing the
+# cap after days of uptime. Below ~2GB the scale factor clamps to 1.0 and
+# there is no slack to redistribute, so tiny instances keep the legacy base.
+if [ "$TOTAL_MEM" -ge 1800 ]; then
+    POSTGREST_BASE=150
+else
+    POSTGREST_BASE=50
+fi
+
+# Total base memory
+TOTAL_BASE=$(( POSTGRES_BASE + POSTGREST_BASE + INSFORGE_BASE ))
+echo "Base total memory: ${TOTAL_BASE}MB"
 
 # Set AVAILABLE_MEM to TOTAL_MEM for calculation
 AVAILABLE_MEM=$TOTAL_MEM
@@ -87,31 +96,14 @@ else                                  PG_MAX_CONNECTIONS=30;  PGRST_DB_POOL=15  
 fi
 echo "Connection scaling: PGRST_DB_POOL=${PGRST_DB_POOL}, PG_MAX_CONNECTIONS=${PG_MAX_CONNECTIONS} (RAM ${TOTAL_MEM}MB)"
 
-# --- Scale CPU limits with instance core count ----------------------------------
-# Base config totals 1.3 cpus (0.5 + 0.3 + 0.5), sized for the smallest instances.
-# Reserve 0.3 cores for the host (dockerd, log drivers, ssh), split the rest in the
-# same ratio as the base config. Floor at 1.0 so small instances keep the base
-# limits (cpus is a cap, not an allocation, so mild overcommit there is fine).
-CPU_TOTAL_BASE=$(awk "BEGIN {printf \"%.2f\", $POSTGRES_CPUS_BASE + $POSTGREST_CPUS_BASE + $INSFORGE_CPUS_BASE}")
-RESERVED_CPU=0.3
-USABLE_CPUS=$(awk "BEGIN {printf \"%.2f\", $TOTAL_CPUS - $RESERVED_CPU}")
-CPU_SCALE_FACTOR=$(awk "BEGIN {printf \"%.4f\", $USABLE_CPUS / $CPU_TOTAL_BASE}")
-if (( $(awk "BEGIN {print ($CPU_SCALE_FACTOR < 1.0)}") )); then
-    CPU_SCALE_FACTOR=1.0000
-fi
-POSTGRES_CPUS=$(awk "BEGIN {printf \"%.2f\", $POSTGRES_CPUS_BASE * $CPU_SCALE_FACTOR}")
-POSTGREST_CPUS=$(awk "BEGIN {printf \"%.2f\", $POSTGREST_CPUS_BASE * $CPU_SCALE_FACTOR}")
-INSFORGE_CPUS=$(awk "BEGIN {printf \"%.2f\", $INSFORGE_CPUS_BASE * $CPU_SCALE_FACTOR}")
-echo "CPU scaling: factor ${CPU_SCALE_FACTOR} (${TOTAL_CPUS} cores, ${RESERVED_CPU} reserved)"
-
 # Verify total doesn't exceed usable memory
 TOTAL_ALLOCATED=$(( POSTGRES_MEM + POSTGREST_MEM + INSFORGE_MEM ))
 
 echo ""
 echo "=== Calculated Resource Allocation ==="
-echo "postgres:      ${POSTGRES_MEM}MB, ${POSTGRES_CPUS} cpus (base: ${POSTGRES_BASE}MB, ${POSTGRES_CPUS_BASE} cpus)"
-echo "postgrest:     ${POSTGREST_MEM}MB, ${POSTGREST_CPUS} cpus (base: ${POSTGREST_BASE}MB, ${POSTGREST_CPUS_BASE} cpus, GHC heap cap: ${POSTGREST_RTS_HEAP}M)"
-echo "insforge:      ${INSFORGE_MEM}MB, ${INSFORGE_CPUS} cpus (base: ${INSFORGE_BASE}MB, ${INSFORGE_CPUS_BASE} cpus)"
+echo "postgres:      ${POSTGRES_MEM}MB (base: ${POSTGRES_BASE}MB)"
+echo "postgrest:     ${POSTGREST_MEM}MB (base: ${POSTGREST_BASE}MB, GHC heap cap: ${POSTGREST_RTS_HEAP}M)"
+echo "insforge:      ${INSFORGE_MEM}MB (base: ${INSFORGE_BASE}MB)"
 echo "---"
 echo "Total allocated: ${TOTAL_ALLOCATED}MB / ${USABLE_MEM}MB usable"
 echo ""
@@ -131,17 +123,12 @@ cat >> "$ENV_FILE" << EOF
 
 # Auto-generated resource limits - $(date)
 # Total system memory: ${AVAILABLE_MEM}MB
-# Total CPUs: ${TOTAL_CPUS} (${RESERVED_CPU} reserved for host)
 # Usable memory: ${USABLE_MEM}MB (after ${RESERVED_MEM}MB system reservation)
 # Scaling factor: ${SCALE_FACTOR}
-# CPU scaling factor: ${CPU_SCALE_FACTOR}
 POSTGRES_MEMORY=${POSTGRES_MEM}M
 POSTGREST_MEMORY=${POSTGREST_MEM}M
 POSTGREST_RTS_HEAP=${POSTGREST_RTS_HEAP}M
 INSFORGE_MEMORY=${INSFORGE_MEM}M
-POSTGRES_CPUS=${POSTGRES_CPUS}
-POSTGREST_CPUS=${POSTGREST_CPUS}
-INSFORGE_CPUS=${INSFORGE_CPUS}
 PGRST_DB_POOL=${PGRST_DB_POOL}
 PG_MAX_CONNECTIONS=${PG_MAX_CONNECTIONS}
 EOF

--- a/auto-scale-memory.sh
+++ b/auto-scale-memory.sh
@@ -32,8 +32,9 @@ fi
 # PostgREST's share: an equal third on instances with room for it. The legacy
 # 150:50:150 split starved postgrest exactly where load is highest — a 4GB
 # medium gave it 544MB against a 90-connection pool, with its heap grazing the
-# cap after days of uptime. Below ~2GB the scale factor clamps to 1.0 and
-# there is no slack to redistribute, so tiny instances keep the legacy base.
+# cap after days of uptime. Below ~2GB there is little absolute slack — an
+# equal third would shrink postgres/insforge caps on boxes where they are
+# already tight — so tiny instances keep the legacy base.
 if [ "$TOTAL_MEM" -ge 1800 ]; then
     POSTGREST_BASE=150
 else
@@ -96,8 +97,14 @@ else                                  PG_MAX_CONNECTIONS=30;  PGRST_DB_POOL=15  
 fi
 echo "Connection scaling: PGRST_DB_POOL=${PGRST_DB_POOL}, PG_MAX_CONNECTIONS=${PG_MAX_CONNECTIONS} (RAM ${TOTAL_MEM}MB)"
 
-# Verify total doesn't exceed usable memory
+# Verify total doesn't exceed usable memory. Per-service rounding can land
+# up to 2MB over budget (e.g. three .5 round-ups near the 1800MB cutoff);
+# shave any excess off insforge, the least memory-sensitive service.
 TOTAL_ALLOCATED=$(( POSTGRES_MEM + POSTGREST_MEM + INSFORGE_MEM ))
+if [ "$TOTAL_ALLOCATED" -gt "$USABLE_MEM" ]; then
+    INSFORGE_MEM=$(( INSFORGE_MEM - (TOTAL_ALLOCATED - USABLE_MEM) ))
+    TOTAL_ALLOCATED=$USABLE_MEM
+fi
 
 echo ""
 echo "=== Calculated Resource Allocation ==="
@@ -115,7 +122,7 @@ ENV_FILE=".env"
 cp "$ENV_FILE" "${ENV_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
 
 # Remove existing memory settings if present
-sed -i.tmp '/^POSTGRES_MEMORY=/d; /^POSTGREST_MEMORY=/d; /^PGRST_DB_POOL=/d; /^PG_MAX_CONNECTIONS=/d; /^POSTGREST_RTS_HEAP=/d; /^INSFORGE_MEMORY=/d; /^POSTGRES_CPUS=/d; /^POSTGREST_CPUS=/d; /^INSFORGE_CPUS=/d; /^DENO_MEMORY=/d; /^VECTOR_MEMORY=/d; /^NODE_EXPORTER_MEMORY=/d; /^# Auto-generated memory limits/d; /^# Auto-generated resource limits/d; /^# Total system memory:/d; /^# Total CPUs:/d; /^# Usable memory:/d; /^# Scaling factor:/d; /^# CPU scaling factor:/d' "$ENV_FILE"
+sed -i.tmp '/^POSTGRES_MEMORY=/d; /^POSTGREST_MEMORY=/d; /^PGRST_DB_POOL=/d; /^PG_MAX_CONNECTIONS=/d; /^POSTGREST_RTS_HEAP=/d; /^INSFORGE_MEMORY=/d; /^POSTGRES_CPUS=/d; /^POSTGREST_CPUS=/d; /^INSFORGE_CPUS=/d; /^DENO_CPUS=/d; /^VECTOR_CPUS=/d; /^NODE_EXPORTER_CPUS=/d; /^DENO_MEMORY=/d; /^VECTOR_MEMORY=/d; /^NODE_EXPORTER_MEMORY=/d; /^# Auto-generated memory limits/d; /^# Auto-generated resource limits/d; /^# Total system memory:/d; /^# Total CPUs:/d; /^# Usable memory:/d; /^# Scaling factor:/d; /^# CPU scaling factor:/d' "$ENV_FILE"
 rm -f "${ENV_FILE}.tmp"
 
 # Append new resource settings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,13 @@ services:
     container_name: insforge-postgres
     restart: unless-stopped
     command: postgres -c config_file=/etc/postgresql/postgresql.conf -c max_connections=${PG_MAX_CONNECTIONS:-100} -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}'
+    # No hard CPU caps on any service: single-tenant host, so caps only
+    # prevented bursting into idle cores (see auto-scale-memory.sh header).
+    # Memory stays capped — an uncapped leak would invoke the host OOM killer.
     deploy:
       resources:
         limits:
           memory: ${POSTGRES_MEMORY:-150M}
-          cpus: '${POSTGRES_CPUS:-0.5}'
         reservations:
           memory: 30M
     environment:
@@ -56,7 +58,6 @@ services:
       resources:
         limits:
           memory: ${POSTGREST_MEMORY:-50M}
-          cpus: '${POSTGREST_CPUS:-0.3}'
         reservations:
           memory: 20M
     environment:
@@ -100,7 +101,6 @@ services:
       resources:
         limits:
           memory: ${INSFORGE_MEMORY:-150M}
-          cpus: '${INSFORGE_CPUS:-0.5}'
         reservations:
           memory: 50M
     depends_on:


### PR DESCRIPTION
## Why

Palise Tools (b47a8ea8, ap-southeast, t4g.medium) hit a 45-min window of 10s proxy timeouts and socket resets (feedback `2def74a5`). On-box evidence: the postgrest container was capped at **0.3 vCPU / 544MB** while the 2-core host sat at load 0.01 — 16,847 throttled cgroup periods, heap high-water mark already at the memory cap, escalating `timeout of 10000ms exceeded` (0 → 6 → 56/day since Aug 3). Container quotas — not instance class — were the ceiling, so customer resizing cannot fix it.

The legacy 150:50:150 memory split gives postgrest ~14% of RAM on every tier while it runs a RAM-tiered pool (90 connections on a medium), and CPU caps were hard limits that no service could burst past even on an idle host.

## What

- **Remove hard `cpus:` limits from all services.** Single-tenant hosts: caps only prevented bursting into idle cores. Under contention the kernel's default equal `cpu.weight` arbitrates. (Ops follow-up, separate lane: CloudWatch alarm on `CPUCreditBalance` for burstable instances.)
- **Memory caps stay** (host OOM-killer protection) but `POSTGREST_BASE` becomes 150 on instances ≥1800MB → equal thirds. A 4GB medium: postgrest 544MB → **1268MB** (GHC heap cap 1248M). Below ~2GB the 1.0 scale-factor clamp leaves no slack, so nano/micro keep the legacy split.
- `.env` cleanup still strips legacy `*_CPUS=` keys so upgraded instances shed them.

## Verification

Simulated the allocator across 460MB–15.7GB totals: nano/micro results byte-identical to current behavior; every tier stays within usable memory:

| total RAM | postgres | postgrest | insforge | pool |
|---|---|---|---|---|
| 460MB (nano) | 184 | 61 *(unchanged)* | 184 | 15 |
| 1900MB (small) | 623 | 623 | 623 | 45 |
| 3835MB (medium) | 1268 | **1268** (was 544) | 1268 | 90 |
| 7800MB (large) | 2590 | 2590 | 2590 | 150 |

postgres's reduced cap on medium (1631→1268) is safe: `postgresql.conf` is conf-driven (`shared_buffers=32MB`, `work_mem=2MB`); observed RSS on the incident box is 437MB.

Rollout note: this only affects instances that re-run `auto-scale-memory.sh` + `docker-compose up` — existing fleet needs the update pushed (v2.2.9 rollout gap tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpSh9Qb69rJYnKEdMDWPph

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove hard CPU caps and rebalance memory so PostgREST gets an equal share on instances with ≥2GB RAM. This prevents throttling on idle hosts and increases PostgREST headroom (4GB medium: 544MB → 1268MB) to avoid timeouts under load.

- **Bug Fixes**
  - Removed `cpus:` limits from `docker-compose.yml`; rely on kernel fair scheduling. Memory caps stay.
  - Updated `auto-scale-memory.sh` to set `POSTGREST_BASE=150` when total RAM ≥1800MB; tiny tiers keep the legacy 150:50:150 split.
  - `.env` cleanup drops legacy `*_CPUS` keys so upgraded instances shed old caps.

- **Migration**
  - Re-run `auto-scale-memory.sh` and `docker-compose up` on each instance to apply.
  - Optional: add a CloudWatch alarm on `CPUCreditBalance` for burstable hosts.

<sup>Written for commit adaee6ae887d8d683872347cce2bfa03936bcaa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Simplified resource allocation by focusing on memory limits and reservations.
  * Dynamically adjusts PostgREST’s base memory according to available system RAM.
  * Keeps memory, heap, connection, and pool settings visible in resource configuration output.
  * Prevents memory allocations from exceeding usable system memory.
  * Removed CPU limits from key services, allowing more flexible CPU utilization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Note on the postgres cap reduction (medium: 1631→1268MB):** weighed against the 150-connection ceiling — postgres memory is conf-driven (`shared_buffers=32MB`, `work_mem=2MB` per sort/hash), so even 150 connections at several work_mem units each stay well under 1GB; observed RSS on the incident box is 437MB, leaving >2.5× headroom under the new cap.
