### PR TITLE
chore(db): drop logs.sql, a Logflare leftover

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - postgres-data:/var/lib/postgresql/data
       - ./docker-init/db/db-init.sql:/docker-entrypoint-initdb.d/01-init.sql
       - ./docker-init/db/jwt.sql:/docker-entrypoint-initdb.d/02-jwt.sql
-      - ./docker-init/db/logs.sql:/docker-entrypoint-initdb.d/03-logs.sql
       - ./docker-init/db/postgresql.conf:/etc/postgresql/postgresql.conf
     ports:
       - "5432:5432"

--- a/docker-init/db/logs.sql
+++ b/docker-init/db/logs.sql
@@ -1,9 +1,0 @@
-\set pguser `echo "$POSTGRES_USER"`
-
-CREATE DATABASE _insforge WITH OWNER :pguser;
-
-\c _insforge
-create schema if not exists _analytics;
-alter schema _analytics owner to :pguser;
-
-\c insforge


### PR DESCRIPTION
Every provisioned project gets an extra `_insforge` database containing an empty `_analytics` schema, created at initdb time by this script. Nothing uses it.

## Where it came from

| Date | Commit | Repo | What happened |
| --- | --- | --- | --- |
| 2025-08-01 | `9d02dc246` | InsForge | "add vector and logflare image" — introduces `docker-init/db/logs.sql` alongside the Logflare stack |
| 2025-08-11 | `d2b44b9` | standalone | "first version" — copies the tree wholesale, `logs.sql` included |
| 2025-10-01 | `dc953b7a3` | InsForge | "removed logs folder" — deletes `logs.sql` and its compose mounts, moving to the CloudWatch log provider |

The InsForge side removed it ten months ago. This copy was never pruned, so the script has kept running on every provision since.

## Evidence it's unused

- Zero references to `_insforge` or `_analytics` in `InsForge/backend/src`
- Zero references in `insforge-cloud-backend/src` (and none anywhere in that repo)
- Measured on a fresh cluster: the extra database is **7329 kB** (Postgres copies template1), and `_analytics` holds **0 tables**

## Verification

Ran `ghcr.io/insforge/postgres:v15.13.4` with the remaining init scripts mounted exactly as this compose file does, before and after:

```
with logs.sql     _insforge  insforge  postgres  template0  template1
without           　         insforge  postgres  template0  template1
```

- The `anon` / `authenticated` / `project_admin` roles from `db-init.sql` are unaffected.
- The transient `FATAL: database "insforge" does not exist` during initdb appears identically in both runs — pre-existing startup noise, not introduced here.
- `docker compose config` validates.

## Scope, and what this does *not* fix

Init scripts run only when a data directory is created, so **this affects newly provisioned projects only**. Existing projects keep their `_insforge` database until someone drops it deliberately — I've deliberately not included any migration or `DROP DATABASE`, since provisioning scripts, backup flows and monitoring queries are worth checking first.

Separately: `ghcr.io/insforge/postgres-all` also bakes this script in as `03-logs.sql`, so anything using that image keeps creating the database until it's rebuilt from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused init script that created a blank `_insforge` database with an `_analytics` schema. New provisions no longer create this extra database.

- **Refactors**
  - Deleted `docker-init/db/logs.sql`.
  - Removed its mount from `docker-compose.yml`.
  - No changes to other init scripts or roles.

- **Migration**
  - Affects new projects only; existing projects keep `_insforge` until manually dropped.
  - Environments using `ghcr.io/insforge/postgres-all` will still create it until that image is rebuilt.

<sup>Written for commit 6f1af32ab128a9e866228a6a4750c29640b9e8d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

