### PR TITLE
fix(db): set pg_net.database_name so async SQL HTTP actually runs

### DIFF
--- a/docker-init/db/postgresql.conf
+++ b/docker-init/db/postgresql.conf
@@ -25,6 +25,7 @@ insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messa
 insforge.internal_schemas = 'ai,auth,compute,deployments,email,functions,memory,monitoring,payments,realtime,schedules,storage,system'
 
 cron.database_name = 'insforge'
+pg_net.database_name = 'insforge' # pg_net's worker only serves one database
 
 # Memory tuning for low-memory environments (< 1GB total RAM)
 shared_buffers = 32MB


### PR DESCRIPTION
One line. **Async SQL HTTP has been non-functional on every provisioned project since 2026-01-15.**

```diff
 cron.database_name = 'insforge'
+pg_net.database_name = 'insforge' # pg_net's worker only serves one database
```

## The bug

`pg_net` has been in `shared_preload_libraries` since `60c78d5` ("update pgnet", 2026-01-15). But its background worker serves exactly **one** database and defaults to `postgres`. Requests queued by `net.http_*` from `insforge` — the database every project actually uses — are never picked up.

It fails **silently**, which is why nobody noticed:

- `CREATE EXTENSION pg_net` succeeds
- `net.http_get()` returns a request id
- the row sits in `net.http_request_queue` forever
- no error surfaces anywhere

## Measured

On `ghcr.io/insforge/postgres:v15.13.4` with this conf, queuing one `net.http_get()` from `insforge`:

| | `pg_net.database_name` | worker's database | `net.http_request_queue` | `net._http_response` |
| --- | --- | --- | --- | --- |
| before | `postgres` (default) | `postgres` | **1** | 0 |
| after | `insforge` | `insforge` | 0 | 1 |

`cron.database_name` was already set for exactly this reason; pg_cron is unaffected (still `insforge`).

## Provenance

Found while adding `pg_net` to the self-hosted conf in InsForge#1873, where a reviewer caught the missing setting there. Cloud turned out to have the same gap — and unlike self-hosted, cloud has had `pg_net` preloaded (and therefore advertised as available) for seven months.

## Note

Like `cron.database_name`, this hardcodes `insforge` while `POSTGRES_DB` is overridable — `postgresql.conf` doesn't interpolate env vars. Pre-existing for pg_cron; matched the pattern rather than diverging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `pg_net.database_name` to `insforge` so async SQL HTTP (`net.http_*`) is actually processed in the app database. Fixes a silent issue where requests sat in `net.http_request_queue` because the worker defaulted to `postgres`.

- **Bug Fixes**
  - Configure `pg_net.database_name = 'insforge'` in `postgresql.conf`.
  - Aligns with `cron.database_name` (still `insforge`); `pg_cron` unaffected.
  - Verified: before — queue stuck; after — responses appear in `net._http_response`.

<sup>Written for commit a83702727352a4611ce8dc88a050e79f5cd6d5c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Configured pg_net to use the `insforge` database for network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->