### PR TITLE
chore(db): drop pg_net from shared_preload_libraries

### DIFF
--- a/docker-init/db/postgresql.conf
+++ b/docker-init/db/postgresql.conf
@@ -14,7 +14,7 @@ max_replication_slots = 10
 max_wal_senders = 10
 
 # Shared preload libraries
-shared_preload_libraries = 'pg_cron,http,pgcrypto,vector,pg_net,insforge_pg_utils,pg_stat_statements'
+shared_preload_libraries = 'pg_cron,http,pgcrypto,vector,insforge_pg_utils,pg_stat_statements'
 insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messages,payments.stripe_checkout_sessions,payments.stripe_customer_portal_sessions,payments.razorpay_orders,payments.razorpay_subscriptions'
 
 # InsForge-internal schemas kept off the PostgREST data API (deny-list for


### PR DESCRIPTION
Replaces #110, which wired `pg_net` up instead of removing it.

```diff
-shared_preload_libraries = 'pg_cron,http,pgcrypto,vector,pg_net,insforge_pg_utils,pg_stat_statements'
+shared_preload_libraries = 'pg_cron,http,pgcrypto,vector,insforge_pg_utils,pg_stat_statements'
```

## Why remove rather than fix

`pg_net` has been preloaded since `60c78d5` (2026-01-15) but `pg_net.database_name` was never set. Its worker serves exactly one database and defaults to `postgres`, so `net.http_*` calls from `insforge` — the database every project uses — queued and were never processed. Silently: `CREATE EXTENSION` succeeded, `net.http_get()` returned a request id, and the row sat in `net.http_request_queue` forever.

**Seven months, zero reports.** There's no usage to preserve, and preloading costs a permanent background worker per instance — which matters on the low-memory instance class this conf is otherwise tuned for (`shared_buffers = 32MB`, `max_connections = 60`).

## Impact on projects that already created the extension

Measured against an existing data directory that had run `CREATE EXTENSION pg_net`, then restarted without the preload:

| | Result |
| --- | --- |
| Postgres startup | normal |
| extension row | still present; `DROP EXTENSION pg_net` works |
| `net.http_get()` | `ERROR: pg_net is not in shared_preload_libraries` + a HINT naming the fix |

So the change turns a silent no-op into a loud, self-describing error. Strictly clearer than today, and it tells anyone who does want the extension exactly what to re-add.

## Verification

Fresh cluster with this conf: preload list as expected, and `vector 0.7.4`, `pg_cron 1.6`, `http 1.7` all still install and work.

## Related

InsForge#1873 originally added `pg_net` to the self-hosted conf to match cloud; that was dropped once this asymmetry turned out to be a seven-month-old silent breakage rather than a capability gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `pg_net` from `shared_preload_libraries` to eliminate an unused background worker and make misconfigured `net.http_*` calls fail fast with a clear error instead of silently queuing.

- **Migration**
  - No action if you don’t use `pg_net`; clusters start normally and you may `DROP EXTENSION pg_net`.
  - If you need `pg_net`, add it back to `shared_preload_libraries` and set `pg_net.database_name` to your app database (e.g., `insforge`).

<sup>Written for commit 0d5bd0dd44298a4e9c8ff36cf8642a904ab2c4a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

