### PR TITLE
chore(db): pin the insforge_pg_utils grant roles explicitly

### DIFF
--- a/docker-init/db/postgresql.conf
+++ b/docker-init/db/postgresql.conf
@@ -15,6 +15,10 @@ max_wal_senders = 10
 
 # Shared preload libraries
 shared_preload_libraries = 'pg_cron,http,pgcrypto,vector,insforge_pg_utils,pg_stat_statements'
+# Both default to 'project_admin' inside insforge_pg_utils. Pinned here so the
+# value is visible and can't shift when the extension is rebuilt.
+insforge.policy_grant_role = 'project_admin'
+insforge.extension_grant_role = 'project_admin'
 insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messages,payments.stripe_checkout_sessions,payments.stripe_customer_portal_sessions,payments.razorpay_orders,payments.razorpay_subscriptions'
 
 # InsForge-internal schemas kept off the PostgREST data API (deny-list for


### PR DESCRIPTION
```diff
+# Both default to 'project_admin' inside insforge_pg_utils. Pinned here so the
+# value is visible and can't shift when the extension is rebuilt.
+insforge.policy_grant_role = 'project_admin'
+insforge.extension_grant_role = 'project_admin'
 insforge.policy_grant_tables = '...'
```

`insforge.policy_grant_role` was never declared here — only `policy_grant_tables` was — and `insforge.extension_grant_role` was declared nowhere. Both default to `project_admin` inside the extension (`insforge_pg_utils.c:74-84` and `:98-103`), so **behaviour is unchanged**.

## Why pin them

The default lives in a **compiled `.so`**, invisible to anyone reading this file. Reading this conf, it looks like the policy role is simply unconfigured — I misread it exactly that way while tracing an unrelated bug and spent a while chasing a non-problem. And rebuilding the extension could shift permission behaviour with no diff in any config repo.

`extension_grant_role` matters more than it looks: the hook runs `CREATE/DROP EXTENSION` as the bootstrap superuser (`run_as_user(BOOTSTRAP_SUPERUSERID, …)`), a broader grant than the policy one.

## Verification

On `ghcr.io/insforge/postgres:v15.13.4` with this conf:

```
insforge.extension_grant_role | project_admin | configuration file
insforge.policy_grant_role    | project_admin | configuration file
```

`source` moves from `default` to `configuration file` with the value unchanged — which is the whole point. The hook's end-to-end behaviour (project_admin creating a policy on an allowlisted managed table) was verified separately against a properly migrated database in InsForge#1874.

Matches InsForge#1873, which does the same for the self-hosted conf.

Independent of #109 and #111; all three touch this directory but in different places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned `insforge.policy_grant_role` and `insforge.extension_grant_role` in postgresql.conf to 'project_admin' so the effective roles are explicit and stable across extension rebuilds. Behavior is unchanged; these match the `insforge_pg_utils` defaults.

<sup>Written for commit 94d9016db1764018b4b77ac0b510f00d95cf70e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated PostgreSQL permissions to explicitly grant project administrators access to policy and extension management.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->