### PR TITLE
feat(podman): Ubuntu/podman runtime profile + insforge-ctl

### DIFF
--- a/insforge-ctl
+++ b/insforge-ctl
@@ -30,6 +30,26 @@ detect_runtime() {
 }
 RUNTIME=$(detect_runtime)
 
+# Self-elevate for podman. systemctl/podman need root, but the control plane
+# runs instance commands as ec2-user. Callers therefore invoke this script
+# plainly (no sudo) and it re-execs the *installed, root-owned* copy under a
+# narrowly scoped sudoers rule.
+#
+# Why not let callers sudo this file directly: the repo checkout is owned by
+# ec2-user and updated by `git pull`, so a sudoers rule covering it would let
+# ec2-user rewrite the script and run arbitrary code as root -- blanket root
+# with extra steps. Only /usr/local/bin/insforge-ctl is root-owned, so only it
+# is safe to grant. The compose path needs no elevation at all (docker runs via
+# the docker group), which is why this is podman-only.
+INSTALLED_CTL=/usr/local/bin/insforge-ctl
+if [ "$RUNTIME" = podman ] && [ "$(id -u)" != 0 ]; then
+  [ -x "$INSTALLED_CTL" ] || {
+    echo "insforge-ctl: podman needs root and $INSTALLED_CTL is not installed" >&2
+    exit 1
+  }
+  exec sudo -n "$INSTALLED_CTL" "$@"
+fi
+
 compose() { (cd "$PROJECT_DIR" && docker-compose "$@"); }
 
 # Load .env for the DB credentials used by the psql/pg_dump verbs.

--- a/insforge-ctl
+++ b/insforge-ctl
@@ -21,8 +21,13 @@ APP_UNITS=(insforge-postgres insforge-postgrest insforge)
 detect_runtime() {
   if [ -f "$QUADLET_MARKER" ] && command -v podman >/dev/null 2>&1; then
     echo podman
-  elif command -v docker-compose >/dev/null 2>&1 || command -v docker >/dev/null 2>&1; then
+  elif command -v docker-compose >/dev/null 2>&1; then
     echo compose
+  elif command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    # Compose V2 plugin only (no `docker-compose` shim). The current fleet is
+    # all V1, but detecting `compose` and then calling a binary that does not
+    # exist would fail every verb, so pick the form that is actually present.
+    echo compose-v2
   else
     echo "insforge-ctl: no container runtime detected" >&2
     exit 1
@@ -50,7 +55,13 @@ if [ "$RUNTIME" = podman ] && [ "$(id -u)" != 0 ]; then
   exec sudo -n "$INSTALLED_CTL" "$@"
 fi
 
-compose() { (cd "$PROJECT_DIR" && docker-compose "$@"); }
+compose() {
+  if [ "$RUNTIME" = compose-v2 ]; then
+    (cd "$PROJECT_DIR" && docker compose "$@")
+  else
+    (cd "$PROJECT_DIR" && docker-compose "$@")
+  fi
+}
 
 # Load .env for the DB credentials used by the psql/pg_dump verbs.
 load_env() {

--- a/insforge-ctl
+++ b/insforge-ctl
@@ -43,6 +43,29 @@ load_env() {
   PGPASS_="${POSTGRES_PASSWORD:-postgres}"
 }
 
+# Re-install the quadlet units from the repo and re-derive the app image tag
+# from .env. Both matter because the control plane's flows assume compose
+# semantics: `git pull` then restart deployed a changed compose file, and
+# rewriting INSFORGE_OSS_VER in .env then restarting changed the image. Under
+# quadlet the units live in /etc/containers/systemd and the tag lives inside
+# insforge.container, so without this a unit change or a version bump silently
+# no-ops on podman.
+sync_units() {
+  [ "$RUNTIME" = podman ] || return 0
+  local src="$PROJECT_DIR/systemd"
+  [ -d "$src" ] || return 0
+  install -m 0644 "$src"/*.container "$src"/*.network /etc/containers/systemd/ 2>/dev/null || true
+  install -m 0755 "$src/insforge-render-env" /usr/local/bin/insforge-render-env 2>/dev/null || true
+  local ver
+  ver=$(grep -E '^INSFORGE_OSS_VER=' "$PROJECT_DIR/.env" 2>/dev/null | cut -d= -f2)
+  if [ -n "$ver" ]; then
+    sed -i "s|^Image=ghcr.io/insforge/insforge-oss:.*|Image=ghcr.io/insforge/insforge-oss:${ver}|" \
+      /etc/containers/systemd/insforge.container
+    podman pull "ghcr.io/insforge/insforge-oss:${ver}" >/dev/null 2>&1 || true
+  fi
+  systemctl daemon-reload
+}
+
 usage() {
   cat >&2 <<'USAGE'
 usage: insforge-ctl <verb> [args]
@@ -50,7 +73,8 @@ usage: insforge-ctl <verb> [args]
   runtime              print the detected runtime (podman|compose)
   up                   start the whole stack
   down                 stop the whole stack
-  restart              restart the whole stack (re-renders env first on podman)
+  restart              restart the whole stack (re-syncs units/env first on podman)
+  restart-app          restart only the app container, leaving Postgres up
   stop-apps            stop insforge + postgrest, leave postgres running
   start-all            start everything (used after stop-apps)
   upgrade <version>    switch the app image tag and restart
@@ -72,6 +96,7 @@ case "$verb" in
 
   up)
     if [ "$RUNTIME" = podman ]; then
+      sync_units
       /usr/local/bin/insforge-render-env
       systemctl daemon-reload
       systemctl start "${APP_UNITS[@]}"
@@ -90,15 +115,30 @@ case "$verb" in
 
   restart)
     if [ "$RUNTIME" = podman ]; then
-      # Re-render first: the control plane appends new keys to .env (Deno
-      # tokens, reserved secrets) and expects a restart to pick them up —
-      # that was implicit with compose, which re-read .env on every `up`.
+      # Re-sync units and the image tag, then re-render env: the control
+      # plane appends keys to .env and rewrites INSFORGE_OSS_VER, and expects a
+      # restart to pick both up — implicit under compose, which re-read .env
+      # and the compose file on every `up`.
+      sync_units
       /usr/local/bin/insforge-render-env
       systemctl daemon-reload
       systemctl restart "${APP_UNITS[@]}"
     else
       compose down
       compose up -d
+    fi
+    ;;
+
+  restart-app)
+    # App only. The reserved-secrets reset needs the app to re-read its
+    # secrets without bouncing Postgres, which a full-stack restart would do.
+    if [ "$RUNTIME" = podman ]; then
+      sync_units
+      /usr/local/bin/insforge-render-env
+      systemctl daemon-reload
+      systemctl restart insforge
+    else
+      compose restart insforge
     fi
     ;;
 

--- a/insforge-ctl
+++ b/insforge-ctl
@@ -1,0 +1,174 @@
+#!/bin/bash
+# insforge-ctl — runtime-agnostic control surface for a project instance.
+#
+# Why this exists: the fleet runs two container runtimes during the migration
+# (AL2023 + docker-compose, and Ubuntu + podman/quadlet), and an instance can
+# switch from one to the other without warning — a paused project's restore
+# provisions a brand-new instance from whatever AMI is current, so a project
+# created under compose can come back under podman. Encoding the runtime in
+# the control plane (a DB flag, a per-project branch) means two sources of
+# truth that eventually disagree. Instead the instance reports what it is:
+# every caller runs the same verbs here and this script picks the mechanism.
+#
+# Callers: the cloud control plane over SSM, and the backup/restore scripts.
+set -euo pipefail
+
+PROJECT_DIR=${INSFORGE_PROJECT_DIR:-/home/ec2-user/insforge-standalone}
+COMPOSE_FILE="$PROJECT_DIR/docker-compose.yml"
+QUADLET_MARKER=/etc/containers/systemd/insforge-postgres.container
+APP_UNITS=(insforge-postgres insforge-postgrest insforge)
+
+detect_runtime() {
+  if [ -f "$QUADLET_MARKER" ] && command -v podman >/dev/null 2>&1; then
+    echo podman
+  elif command -v docker-compose >/dev/null 2>&1 || command -v docker >/dev/null 2>&1; then
+    echo compose
+  else
+    echo "insforge-ctl: no container runtime detected" >&2
+    exit 1
+  fi
+}
+RUNTIME=$(detect_runtime)
+
+compose() { (cd "$PROJECT_DIR" && docker-compose "$@"); }
+
+# Load .env for the DB credentials used by the psql/pg_dump verbs.
+load_env() {
+  set -a
+  # shellcheck disable=SC1091
+  source "$PROJECT_DIR/.env"
+  set +a
+  PGUSER_="${POSTGRES_USER:-postgres}"
+  PGDB_="${POSTGRES_DB:-insforge}"
+  PGPASS_="${POSTGRES_PASSWORD:-postgres}"
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: insforge-ctl <verb> [args]
+
+  runtime              print the detected runtime (podman|compose)
+  up                   start the whole stack
+  down                 stop the whole stack
+  restart              restart the whole stack (re-renders env first on podman)
+  stop-apps            stop insforge + postgrest, leave postgres running
+  start-all            start everything (used after stop-apps)
+  upgrade <version>    switch the app image tag and restart
+  prune                reclaim unused image/layer storage
+  psql [args...]       run psql against the project DB (stdin passthrough)
+  pg_dump [args...]    run pg_dump against the project DB (stdout passthrough)
+  status               one line per service
+USAGE
+  exit 64
+}
+
+[ $# -ge 1 ] || usage
+verb=$1; shift || true
+
+case "$verb" in
+  runtime)
+    echo "$RUNTIME"
+    ;;
+
+  up)
+    if [ "$RUNTIME" = podman ]; then
+      /usr/local/bin/insforge-render-env
+      systemctl daemon-reload
+      systemctl start "${APP_UNITS[@]}"
+    else
+      compose up -d
+    fi
+    ;;
+
+  down)
+    if [ "$RUNTIME" = podman ]; then
+      systemctl stop "${APP_UNITS[@]}" || true
+    else
+      compose down
+    fi
+    ;;
+
+  restart)
+    if [ "$RUNTIME" = podman ]; then
+      # Re-render first: the control plane appends new keys to .env (Deno
+      # tokens, reserved secrets) and expects a restart to pick them up —
+      # that was implicit with compose, which re-read .env on every `up`.
+      /usr/local/bin/insforge-render-env
+      systemctl daemon-reload
+      systemctl restart "${APP_UNITS[@]}"
+    else
+      compose down
+      compose up -d
+    fi
+    ;;
+
+  stop-apps)
+    if [ "$RUNTIME" = podman ]; then
+      systemctl stop insforge insforge-postgrest || true
+    else
+      compose stop insforge postgrest
+    fi
+    ;;
+
+  start-all)
+    "$0" up
+    ;;
+
+  upgrade)
+    [ $# -ge 1 ] || usage
+    version=$1
+    sed -i "s|^INSFORGE_OSS_VER=.*|INSFORGE_OSS_VER=${version}|" "$PROJECT_DIR/.env"
+    if [ "$RUNTIME" = podman ]; then
+      sed -i "s|^Image=ghcr.io/insforge/insforge-oss:.*|Image=ghcr.io/insforge/insforge-oss:${version}|" \
+        /etc/containers/systemd/insforge.container
+      podman pull "ghcr.io/insforge/insforge-oss:${version}"
+      /usr/local/bin/insforge-render-env
+      systemctl daemon-reload
+      systemctl restart insforge
+    else
+      compose pull insforge
+      compose up -d
+    fi
+    ;;
+
+  prune)
+    if [ "$RUNTIME" = podman ]; then
+      podman system prune -a -f
+    else
+      docker system prune -a -f
+    fi
+    ;;
+
+  # psql/pg_dump: on podman the host has a postgresql client and the server
+  # listens on 127.0.0.1, so no container round-trip is needed. On compose we
+  # keep going through the container because the AL2023 host has no client.
+  psql)
+    load_env
+    if [ "$RUNTIME" = podman ]; then
+      PGPASSWORD="$PGPASS_" psql -h 127.0.0.1 -U "$PGUSER_" -d "$PGDB_" "$@"
+    else
+      compose exec -T postgres env PGPASSWORD="$PGPASS_" psql -U "$PGUSER_" -d "$PGDB_" "$@"
+    fi
+    ;;
+
+  pg_dump)
+    load_env
+    if [ "$RUNTIME" = podman ]; then
+      PGPASSWORD="$PGPASS_" pg_dump -h 127.0.0.1 -U "$PGUSER_" "$@" "$PGDB_"
+    else
+      compose exec -T postgres env PGPASSWORD="$PGPASS_" pg_dump -U "$PGUSER_" "$@" "$PGDB_"
+    fi
+    ;;
+
+  status)
+    if [ "$RUNTIME" = podman ]; then
+      for u in "${APP_UNITS[@]}"; do echo "$u: $(systemctl is-active "$u")"; done
+    else
+      compose ps --format '{{.Name}}: {{.State}}' 2>/dev/null || compose ps
+    fi
+    ;;
+
+  *)
+    usage
+    ;;
+esac

--- a/provisioning/ubuntu-bake.sh
+++ b/provisioning/ubuntu-bake.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# InsForge project-instance AMI bake script — Ubuntu 24.04 LTS (arm64)
+#
+# Run against a fresh Canonical Ubuntu 24.04 arm64 instance, then create-image.
+# Every step here is derived from a spike finding; see the comments for which.
+# Base AMI: resolve per region from
+#   /aws/service/canonical/ubuntu/server/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+log() { echo "=== $* ==="; }
+
+# ---------------------------------------------------------------------------
+# 1. SSM agent: snap -> deb.  MUST happen at bake time.
+#
+# Canonical's AMI ships the agent as a snap. Swapping it on a *running* fleet
+# instance is impossible: the deb's preinst aborts while the snap is present,
+# and removing the snap kills the agent executing the script (verified twice,
+# two different failure modes). At bake time we can sequence it safely because
+# losing the management channel mid-bake is recoverable.
+# Payoff: snapd (~18MB) + snap wrapper overhead gone; deb agent is ~6MB
+# lighter than the snap build.
+# ---------------------------------------------------------------------------
+log "SSM agent: snap -> deb"
+snap remove amazon-ssm-agent || true
+apt-get purge -y snapd
+apt-get autoremove -y
+curl -fsSLo /tmp/ssm.deb \
+  "https://amazon-ssm-${AWS_REGION:-us-east-2}.s3.${AWS_REGION:-us-east-2}.amazonaws.com/latest/debian_arm64/amazon-ssm-agent.deb"
+dpkg -i /tmp/ssm.deb
+systemctl enable --now amazon-ssm-agent
+systemctl is-active --quiet amazon-ssm-agent || { echo "FATAL: deb SSM agent not active"; exit 1; }
+rm -f /tmp/ssm.deb
+
+# ---------------------------------------------------------------------------
+# 2. Runtime + tooling
+#
+# postgresql-client-16: the control plane's backup/restore/branch commands run
+# psql/pg_dump on the HOST against 127.0.0.1 instead of `exec`ing into a
+# container. Keep the client major at 16 against a 15 server (pg_dump 17+
+# emits settings a 15 server rejects).
+# ---------------------------------------------------------------------------
+# awscli: the control plane's backup/restore/branch helpers shell out to
+# `aws s3 cp`, and the user-data SSM-association wait calls `aws ssm`. AL2023
+# ships the CLI preinstalled; Ubuntu does not, and its absence is quiet — the
+# wait loop just burns its full 120s timeout logging "aws: command not found"
+# and backups fail later, at the worst possible moment.
+#
+# The CLI cannot come from apt: `awscli` has no candidate on 24.04 even with
+# universe enabled (verified — Candidate: (none)). Use the vendor installer,
+# which needs unzip, and install unzip from apt here so the provisioning script
+# never has to: this image ships with /var/lib/apt/lists emptied by the cleanup
+# below, so any apt-get install at provisioning time fails with "Unable to
+# locate package" unless it runs apt-get update first.
+log "Installing podman + tooling"
+apt-get update -qq
+apt-get install -y -qq \
+  podman \
+  postgresql-client-16 \
+  systemd-zram-generator \
+  unzip \
+  git curl jq zstd
+
+log "Installing AWS CLI v2 (vendor installer)"
+cd /tmp
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o awscliv2.zip
+unzip -q -o awscliv2.zip
+./aws/install --update >/dev/null
+rm -rf awscliv2.zip aws
+aws --version || { echo "FATAL: aws cli missing after install"; exit 1; }
+
+# fluent-bit from the vendor's official Ubuntu repo (journald -> CloudWatch;
+# podman has no awslogs driver, so this replaces dockerd's built-in shipping).
+log "Installing fluent-bit"
+curl -fsSL https://packages.fluentbit.io/fluentbit.key | gpg --dearmor \
+  > /usr/share/keyrings/fluent-bit.gpg
+echo 'deb [signed-by=/usr/share/keyrings/fluent-bit.gpg] https://packages.fluentbit.io/ubuntu/noble noble main' \
+  > /etc/apt/sources.list.d/fluent-bit.list
+apt-get update -qq
+apt-get install -y -qq fluent-bit
+systemctl disable fluent-bit   # provisioning enables it after writing the config
+
+# node_exporter: fleet metrics (Prometheus scrapes project_id-labelled host
+# metrics; nothing container-aware, so this is unchanged from AL2023).
+log "Installing node_exporter"
+NE_VER=1.8.2
+curl -fsSL "https://github.com/prometheus/node_exporter/releases/download/v${NE_VER}/node_exporter-${NE_VER}.linux-arm64.tar.gz" \
+  | tar -xz -C /tmp
+install -m 0755 "/tmp/node_exporter-${NE_VER}.linux-arm64/node_exporter" /usr/local/bin/node_exporter
+rm -rf "/tmp/node_exporter-${NE_VER}.linux-arm64"
+cat > /etc/systemd/system/node_exporter.service <<'UNIT'
+[Unit]
+Description=Prometheus Node Exporter
+After=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/node_exporter --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($|/) --web.listen-address=:9100
+Restart=always
+Environment=GOMEMLIMIT=24MiB
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl enable node_exporter
+
+# ---------------------------------------------------------------------------
+# 3. zram — REQUIRED, and verify the effective size.
+#
+# Ubuntu ships no zram by default; a 418MB nano cannot survive without it.
+# Gotcha: installing systemd-zram-generator creates zram0 immediately with
+# package defaults (ram/2 = ~204MB). Writing the config afterwards does NOT
+# resize a live device — only the next boot picks it up. Always assert the
+# post-reboot size (AL2023 gives zram == full RAM; match that).
+# ---------------------------------------------------------------------------
+log "Configuring zram"
+cat > /etc/systemd/zram-generator.conf <<'ZRAM'
+[zram0]
+zram-size = ram
+compression-algorithm = lzo-rle
+ZRAM
+
+# ---------------------------------------------------------------------------
+# 4. Service trim — the Ubuntu equivalent of the AL2023 audit.
+#
+# Measured on a spike instance: an untrimmed Ubuntu base runs ~40-50MB heavier
+# than a trimmed AL2023 one, which swallows podman's entire runtime saving
+# (untrimmed Ubuntu+podman measured WORSE than AL2023+podman). This step is
+# not optional cleanup — it is what makes the distro switch break even.
+#
+#   multipathd (~25MB)          multipath SAN I/O; EBS-only instances have none
+#   ModemManager                cellular modems; obviously absent
+#   networkd-dispatcher (~9MB)  hook runner for netplan events; we have no hooks
+#   udisks2 (~8MB)              desktop removable-media daemon
+#   unattended-upgrades (~8MB)  we control patching via AMI rebake
+#   packagekitd (~10MB)         desktop package-management D-Bus service
+# ---------------------------------------------------------------------------
+log "Trimming unused services"
+for u in multipathd multipathd.socket ModemManager networkd-dispatcher \
+         udisks2 unattended-upgrades packagekit packagekit-offline-update; do
+  systemctl disable --now "$u" 2>/dev/null || true
+done
+# Mask the two that get pulled back in by dependencies.
+systemctl mask multipathd multipathd.socket ModemManager 2>/dev/null || true
+apt-get purge -y unattended-upgrades packagekit 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# 5. Cleanup so the image ships small and without instance identity
+# ---------------------------------------------------------------------------
+log "Cleaning up"
+apt-get autoremove -y
+apt-get clean
+rm -rf /var/lib/apt/lists/* /var/log/cloud-init*.log /var/log/syslog* \
+       /home/ubuntu/.ssh/authorized_keys /root/.ssh/authorized_keys 2>/dev/null || true
+cloud-init clean --logs 2>/dev/null || true
+rm -f /etc/machine-id && touch /etc/machine-id   # regenerated at first boot
+
+log "Bake complete. Verify after create-image + first boot:"
+cat <<'CHECKS'
+  systemctl is-active amazon-ssm-agent      # deb agent, must be active
+  which snap                                # must be absent
+  zramctl                                   # DISKSIZE must equal total RAM
+  podman info --format '{{.Store.GraphDriverName}}'   # must be "overlay", not fuse
+  podman run --rm --log-driver=journald alpine echo ok   # journald driver works
+  systemctl list-units --type=service --state=running | wc -l   # expect ~14-16
+  aws --version                             # must print aws-cli/2.x
+  command -v unzip                          # must exist; apt lists are empty here
+CHECKS
+
+# The last two checks exist because the first baked image shipped without the
+# AWS CLI and without unzip, and nothing noticed: provisioning "succeeded",
+# the SSM wait loop logged "aws: command not found" for its whole timeout, and
+# the first backup produced a 20-byte empty gzip that the control plane
+# recorded as a completed restore point. A post-boot check for every binary the
+# control plane shells out to is cheaper than finding it that way.

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,60 @@
+# Podman / quadlet runtime profile
+
+The Ubuntu 24.04 + podman variant of a project instance. Selected by which AMI
+the control plane launches; nothing in the control plane needs to know which
+one it got, because every operation goes through `insforge-ctl`, which detects
+the runtime on the instance itself.
+
+## Why detection instead of a flag
+
+A project's runtime is not stable over its lifetime. Pausing terminates the
+instance and restoring provisions a fresh one from whatever AMI is current, so
+a project created on AL2023 + docker-compose can legitimately come back on
+Ubuntu + podman with no change to the project itself. Any runtime marker
+stored in the control plane is a second source of truth that drifts from the
+instance the moment that happens. `insforge-ctl runtime` asks the machine.
+
+## Files
+
+| File | Installed to | Purpose |
+|---|---|---|
+| `insforge.network` | `/etc/containers/systemd/` | Bridge network for the three services |
+| `insforge-postgres.container` | `/etc/containers/systemd/` | Postgres; `--network-alias=postgres` |
+| `insforge-postgrest.container` | `/etc/containers/systemd/` | PostgREST; `--network-alias=postgrest` |
+| `insforge.container` | `/etc/containers/systemd/` | App; inherits the CloudFront PEM via `-e` |
+| `insforge-render-env` | `/usr/local/bin/` | `.env` → per-service env files, secrets drop-in, limit drop-ins |
+
+`../insforge-ctl` → `/usr/local/bin/insforge-ctl` (shared by both runtimes).
+
+## Two non-obvious constraints, both learned the hard way
+
+**Container DNS names are container names, not compose service aliases.** The
+app connects to `postgres:5432` and PostgREST to `postgres`, but quadlet
+registers the container as `insforge-postgres`. Without
+`PodmanArgs=--network-alias=postgres` the app cannot resolve its database and
+crash-loops through migrations. Same for `postgrest`.
+
+**Multi-line values cannot travel in an env file.** `AWS_CLOUDFRONT_PRIVATE_KEY`
+is a PEM; neither systemd's `EnvironmentFile=` nor podman's `--env-file` parses
+a value containing newlines. `insforge-render-env` writes it into
+`/etc/systemd/system/insforge.service.d/secrets.conf` as a systemd
+`Environment="KEY=…\n…"` string (systemd unescapes `\n` in quoted values), and
+the unit passes it through with a valueless `-e AWS_CLOUDFRONT_PRIVATE_KEY`,
+which tells podman to inherit it from the process environment. Verified
+byte-for-byte inside the container.
+
+## Other things worth knowing before editing these
+
+- Quadlet-generated units **cannot** be `systemctl enable`d ("transient or
+  generated"). Boot start comes from `[Install] WantedBy=` inside the
+  `.container` file, which quadlet honours at generation time.
+- podman 4.9 (what Ubuntu 24.04 ships) has no `Notify=healthy`, so dependent
+  units gate on the database with an `ExecStartPre` `pg_isready` loop rather
+  than on the container's health status. `Notify=healthy` lands in podman 5.0
+  and this can be simplified then.
+- Resource limits are cgroup settings on the units, written by
+  `insforge-render-env` from the `*_MEMORY` / `*_CPUS` values that
+  `auto-scale-memory.sh` puts in `.env` — not `PodmanArgs`. This buys
+  `MemoryHigh` (throttle before the OOM killer), which compose could not express.
+- `insforge-render-env` runs on every `insforge-ctl restart`, so appending a
+  key to `.env` and restarting behaves the way it did under compose.

--- a/systemd/insforge-postgres.container
+++ b/systemd/insforge-postgres.container
@@ -19,7 +19,14 @@ HealthInterval=10s
 HealthRetries=30
 HealthStartPeriod=60s
 PodmanArgs=--network-alias=postgres
-Exec=postgres -c config_file=/etc/postgresql/postgresql.conf -c max_connections=30
+# max_connections and app.encryption_key are stamped here by
+# insforge-render-env from .env on every start -- they cannot be read from the
+# EnvironmentFile because they are server start parameters, and they cannot be
+# constants because auto-scale-memory.sh sizes max_connections per instance
+# tier. app.encryption_key is what schedules.encrypt_headers/decrypt_headers
+# read via current_setting(); without it, scheduled functions with headers
+# raise. Compose passed both on the command line for the same reasons.
+Exec=postgres -c config_file=/etc/postgresql/postgresql.conf -c max_connections=100
 
 [Service]
 Restart=always

--- a/systemd/insforge-postgres.container
+++ b/systemd/insforge-postgres.container
@@ -1,0 +1,29 @@
+[Unit]
+Description=InsForge Postgres (quadlet)
+After=network-online.target
+Wants=network-online.target
+
+[Container]
+ContainerName=insforge-postgres
+Image=ghcr.io/insforge/postgres:v15.13.4
+Network=insforge.network
+PublishPort=5432:5432
+Volume=insforge-pgdata:/var/lib/postgresql/data
+Volume=/home/ec2-user/insforge-standalone/docker-init/db/db-init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
+Volume=/home/ec2-user/insforge-standalone/docker-init/db/jwt.sql:/docker-entrypoint-initdb.d/02-jwt.sql:ro
+Volume=/home/ec2-user/insforge-standalone/docker-init/db/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+EnvironmentFile=/etc/insforge/postgres.env
+LogDriver=journald
+HealthCmd=pg_isready -U postgres -d insforge -h 127.0.0.1
+HealthInterval=10s
+HealthRetries=30
+HealthStartPeriod=60s
+PodmanArgs=--network-alias=postgres
+Exec=postgres -c config_file=/etc/postgresql/postgresql.conf -c max_connections=30
+
+[Service]
+Restart=always
+TimeoutStartSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/insforge-postgrest.container
+++ b/systemd/insforge-postgrest.container
@@ -1,0 +1,22 @@
+[Unit]
+Description=InsForge PostgREST (quadlet)
+After=insforge-postgres.service
+Requires=insforge-postgres.service
+
+[Container]
+ContainerName=insforge-postgrest
+Image=docker.io/postgrest/postgrest:v12.2.12
+Network=insforge.network
+PublishPort=5430:3000
+EnvironmentFile=/etc/insforge/postgrest.env
+LogDriver=journald
+PodmanArgs=--network-alias=postgrest
+Exec=postgrest +RTS -M35M -A2m -H24m -N1 -RTS
+
+[Service]
+Restart=always
+# Gate on the DB actually accepting connections (podman 4.9 has no Notify=healthy)
+ExecStartPre=/bin/sh -c 'for i in $(seq 1 60); do /usr/bin/pg_isready -q -h 127.0.0.1 -p 5432 && exit 0; sleep 2; done; exit 1'
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/insforge-postgrest.container
+++ b/systemd/insforge-postgrest.container
@@ -11,7 +11,11 @@ PublishPort=5430:3000
 EnvironmentFile=/etc/insforge/postgrest.env
 LogDriver=journald
 PodmanArgs=--network-alias=postgrest
-Exec=postgrest +RTS -M35M -A2m -H24m -N1 -RTS
+# The GHC heap cap is stamped by insforge-render-env from POSTGREST_RTS_HEAP
+# (auto-scale-memory.sh sizes it per tier as POSTGREST_MEMORY - 20M). Pinning
+# it would leave postgrest heap-starved relative to its cgroup allowance on
+# anything above nano.
+Exec=postgrest +RTS -M30M -A2m -H24m -N1 -RTS
 
 [Service]
 Restart=always

--- a/systemd/insforge-render-env
+++ b/systemd/insforge-render-env
@@ -42,8 +42,13 @@ EOF
 # Single-line vars only. Multi-line values (the CloudFront PEM) cannot be
 # expressed in an env-file at all -- neither systemd's EnvironmentFile= nor
 # podman's --env-file parse them -- so they go through the drop-in below.
-grep -vE '^(AWS_CLOUDFRONT_PRIVATE_KEY=|-----|[A-Za-z0-9+/]{40,}=*$|#|$)' "$ENV_FILE" \
-  | grep '=' > "$OUT/insforge.env"
+# Allowlist real env lines by shape rather than blocklisting PEM bodies: a
+# wrapped base64 tail shorter than 40 chars would slip past a blocklist and
+# land in the env file as a junk variable.
+grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$ENV_FILE" \
+  | grep -v '^AWS_CLOUDFRONT_PRIVATE_KEY=' > "$OUT/insforge.env"
+# POSTGREST_MAX_SOCKETS was a compose literal and is absent from .env; the
+# app's PostgREST connection ceiling has to track the pool auto-scale sized.
 cat >> "$OUT/insforge.env" <<EOF
 POSTGRES_HOST=postgres
 POSTGREST_BASE_URL=http://postgrest:3000
@@ -56,6 +61,7 @@ MAX_JSON_BODY_SIZE=100mb
 MAX_URLENCODED_BODY_SIZE=10mb
 API_BASE_URL=${VITE_API_BASE_URL:-}
 AWS_REGION=${AWS_REGION:-us-east-2}
+POSTGREST_MAX_SOCKETS=${PGRST_DB_POOL:-30}
 EOF
 
 # --- multi-line secrets ---------------------------------------------------
@@ -75,24 +81,46 @@ with open(out, "w") as f:
 PY
 
 # --- resource limits ------------------------------------------------------
-# auto-scale-memory.sh sizes these per instance type and writes them to .env.
-# Under compose they were `deploy.resources.limits`; here they become cgroup
+# auto-scale-memory.sh sizes memory per instance type and writes it to .env.
+# Under compose these were `deploy.resources.limits`; here they become cgroup
 # settings on the generated units, which additionally gives us MemoryHigh --
 # throttle-before-OOM, something compose could not express.
+#
+# Deliberately no CPUQuota. auto-scale-memory.sh removed CPU limits on purpose
+# (see its header: a 0.3-cpu cap on postgrest stalled requests while the host
+# sat at load 0.01) and it strips *_CPUS from .env on every run, so any default
+# here would silently reinstate exactly the cap that was removed. Under
+# contention the kernel's equal cpu.weight arbitrates, as compose now relies on.
 mem_high() { echo "$(( ${1%M} * 90 / 100 ))M"; }
-cpu_pct()  { awk "BEGIN {printf \"%d\", $1 * 100}"; }
-write_limits() {  # unit, memory, cpus
+write_limits() {  # unit, memory
   mkdir -p "/etc/systemd/system/$1.service.d"
   cat > "/etc/systemd/system/$1.service.d/limits.conf" <<LIM
 [Service]
 MemoryMax=$2
 MemoryHigh=$(mem_high "$2")
-CPUQuota=$(cpu_pct "$3")%
 LIM
 }
-write_limits insforge-postgres  "${POSTGRES_MEMORY:-150M}"  "${POSTGRES_CPUS:-0.5}"
-write_limits insforge-postgrest "${POSTGREST_MEMORY:-50M}"  "${POSTGREST_CPUS:-0.3}"
-write_limits insforge           "${INSFORGE_MEMORY:-150M}"  "${INSFORGE_CPUS:-0.5}"
+write_limits insforge-postgres  "${POSTGRES_MEMORY:-150M}"
+write_limits insforge-postgrest "${POSTGREST_MEMORY:-50M}"
+write_limits insforge           "${INSFORGE_MEMORY:-150M}"
+
+# --- per-tier values that must live in the unit Exec lines -----------------
+# max_connections, app.encryption_key and the GHC heap cap are server start
+# parameters, so they cannot come from an EnvironmentFile. Stamp them from .env
+# on every render so they track auto-scale-memory.sh instead of drifting as
+# constants (compose passed them on the command line for the same reason).
+QUADLET_DIR=${QUADLET_DIR:-/etc/containers/systemd}
+PG_UNIT="$QUADLET_DIR/insforge-postgres.container"
+PGRST_UNIT="$QUADLET_DIR/insforge-postgrest.container"
+PG_ENC_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
+if [ -f "$PG_UNIT" ]; then
+  sed -i "s|^Exec=postgres .*|Exec=postgres -c config_file=/etc/postgresql/postgresql.conf -c max_connections=${PG_MAX_CONNECTIONS:-100} -c app.encryption_key=${PG_ENC_KEY}|" \
+    "$PG_UNIT"
+fi
+if [ -f "$PGRST_UNIT" ]; then
+  sed -i "s|^Exec=postgrest .*|Exec=postgrest +RTS -M${POSTGREST_RTS_HEAP:-30M} -A2m -H24m -N1 -RTS|" \
+    "$PGRST_UNIT"
+fi
 
 chown 0:0 "$OUT"/*.env "$DROPIN/secrets.conf"
 chmod 400 "$OUT"/*.env "$DROPIN/secrets.conf"

--- a/systemd/insforge-render-env
+++ b/systemd/insforge-render-env
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Renders per-service env files + the multi-line-secret drop-in for the
+# quadlet units, from the project .env written by user-data.
+#
+# Run as ExecStartPre (with "+" for root) or from the provisioning script
+# before starting insforge-stack. Re-running is idempotent and is what makes
+# ".env edited -> restart -> takes effect" work the way it did under compose.
+set -euo pipefail
+
+ENV_FILE=${ENV_FILE:-/home/ec2-user/insforge-standalone/.env}
+OUT=/etc/insforge
+DROPIN=/etc/systemd/system/insforge.service.d
+
+# shellcheck disable=SC1090
+set -a; source "$ENV_FILE"; set +a
+umask 077
+mkdir -p "$OUT" "$DROPIN"
+
+# --- postgres -------------------------------------------------------------
+cat > "$OUT/postgres.env" <<EOF
+POSTGRES_USER=${POSTGRES_USER:-postgres}
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+POSTGRES_DB=${POSTGRES_DB:-insforge}
+EOF
+
+# --- postgrest ------------------------------------------------------------
+cat > "$OUT/postgrest.env" <<EOF
+PGRST_DB_URI=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+PGRST_DB_SCHEMA=public
+PGRST_DB_ANON_ROLE=anon
+PGRST_JWT_SECRET=${JWT_SECRET}
+PGRST_DB_POOL=${PGRST_DB_POOL:-30}
+PGRST_DB_POOL_TIMEOUT=10
+PGRST_DB_POOL_ACQUISITION_TIMEOUT=10
+PGRST_DB_CHANNEL_ENABLED=true
+PGRST_DB_CHANNEL=pgrst
+PGRST_MAX_ROWS=1000
+PGRST_OPENAPI_SERVER_PROXY_URI=http://localhost:3000
+EOF
+
+# --- insforge -------------------------------------------------------------
+# Single-line vars only. Multi-line values (the CloudFront PEM) cannot be
+# expressed in an env-file at all -- neither systemd's EnvironmentFile= nor
+# podman's --env-file parse them -- so they go through the drop-in below.
+grep -vE '^(AWS_CLOUDFRONT_PRIVATE_KEY=|-----|[A-Za-z0-9+/]{40,}=*$|#|$)' "$ENV_FILE" \
+  | grep '=' > "$OUT/insforge.env"
+cat >> "$OUT/insforge.env" <<EOF
+POSTGRES_HOST=postgres
+POSTGREST_BASE_URL=http://postgrest:3000
+DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+NODE_ENV=production
+PROJECT_ROOT=/app
+STORAGE_DIR=/insforge-storage
+LOGS_DIR=/insforge-logs
+MAX_JSON_BODY_SIZE=100mb
+MAX_URLENCODED_BODY_SIZE=10mb
+API_BASE_URL=${VITE_API_BASE_URL:-}
+AWS_REGION=${AWS_REGION:-us-east-2}
+EOF
+
+# --- multi-line secrets ---------------------------------------------------
+# systemd's Environment= accepts a double-quoted string with C-style escapes,
+# so the PEM survives as one logical line. The quadlet unit then passes it
+# through with `-e AWS_CLOUDFRONT_PRIVATE_KEY` (no value = inherit from the
+# podman process's environment). Verified byte-for-byte inside the container.
+python3 - "$DROPIN/secrets.conf" <<'PY'
+import os, sys
+out = sys.argv[1]
+pem = os.environ.get("AWS_CLOUDFRONT_PRIVATE_KEY", "")
+esc = pem.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+with open(out, "w") as f:
+    f.write("[Service]\n")
+    if esc:
+        f.write(f'Environment="AWS_CLOUDFRONT_PRIVATE_KEY={esc}"\n')
+PY
+
+# --- resource limits ------------------------------------------------------
+# auto-scale-memory.sh sizes these per instance type and writes them to .env.
+# Under compose they were `deploy.resources.limits`; here they become cgroup
+# settings on the generated units, which additionally gives us MemoryHigh --
+# throttle-before-OOM, something compose could not express.
+mem_high() { echo "$(( ${1%M} * 90 / 100 ))M"; }
+cpu_pct()  { awk "BEGIN {printf \"%d\", $1 * 100}"; }
+write_limits() {  # unit, memory, cpus
+  mkdir -p "/etc/systemd/system/$1.service.d"
+  cat > "/etc/systemd/system/$1.service.d/limits.conf" <<LIM
+[Service]
+MemoryMax=$2
+MemoryHigh=$(mem_high "$2")
+CPUQuota=$(cpu_pct "$3")%
+LIM
+}
+write_limits insforge-postgres  "${POSTGRES_MEMORY:-150M}"  "${POSTGRES_CPUS:-0.5}"
+write_limits insforge-postgrest "${POSTGREST_MEMORY:-50M}"  "${POSTGREST_CPUS:-0.3}"
+write_limits insforge           "${INSFORGE_MEMORY:-150M}"  "${INSFORGE_CPUS:-0.5}"
+
+chown 0:0 "$OUT"/*.env "$DROPIN/secrets.conf"
+chmod 400 "$OUT"/*.env "$DROPIN/secrets.conf"
+echo "rendered: $(ls "$OUT"/*.env | tr '\n' ' ') + secrets drop-in"

--- a/systemd/insforge.container
+++ b/systemd/insforge.container
@@ -4,8 +4,11 @@ After=insforge-postgres.service
 Requires=insforge-postgres.service
 
 [Container]
+# Default tag mirrors docker-compose.yml on this branch; provisioning
+# overwrites this line from INSFORGE_OSS_VER when the control plane pins a
+# version, and `insforge-ctl upgrade <ver>` rewrites it on every upgrade.
 ContainerName=insforge
-Image=ghcr.io/insforge/insforge-oss:v2.2.10-execnode-test
+Image=ghcr.io/insforge/insforge-oss:v2.3.0
 Network=insforge.network
 PublishPort=7130:7130
 PublishPort=7131:7131

--- a/systemd/insforge.container
+++ b/systemd/insforge.container
@@ -1,0 +1,23 @@
+[Unit]
+Description=InsForge API (quadlet)
+After=insforge-postgres.service
+Requires=insforge-postgres.service
+
+[Container]
+ContainerName=insforge
+Image=ghcr.io/insforge/insforge-oss:v2.2.10-execnode-test
+Network=insforge.network
+PublishPort=7130:7130
+PublishPort=7131:7131
+EnvironmentFile=/etc/insforge/insforge.env
+LogDriver=journald
+PodmanArgs=-e AWS_CLOUDFRONT_PRIVATE_KEY
+WorkingDir=/app
+
+[Service]
+Restart=always
+TimeoutStartSec=600
+ExecStartPre=/bin/sh -c 'for i in $(seq 1 60); do /usr/bin/pg_isready -q -h 127.0.0.1 -p 5432 && exit 0; sleep 2; done; exit 1'
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/insforge.network
+++ b/systemd/insforge.network
@@ -1,0 +1,2 @@
+[Network]
+NetworkName=insforge


### PR DESCRIPTION
Foundation for the memory-optimization migration. Adds a second runtime profile (Ubuntu 24.04 + podman/quadlet) and the runtime-agnostic control surface both profiles share. **Nothing changes for existing instances until the control plane starts launching the new AMI** — this PR only adds files.

## Why

A t4g.nano project instance spends ~70MB keeping dockerd + containerd + shims resident to supervise three processes. Podman has no daemon: conmon ×3 costs ~1.1MB. Measured across seven identical fresh nanos, same window, 19-20 min post-boot, total anonymous memory (RAM + swap):

| Configuration | Memory |
|---|---|
| Today's production (docker) | 264MB |
| docker, fully trimmed | 235MB |
| nerdctl + containerd | 232MB |
| AL2023 + systemd, no containers | 172MB |
| **Ubuntu 24.04 + podman + quadlet** | **158MB** |

Major faults dropped from 33k to 19k over the same window — the app runs resident instead of half-swapped.

## The design decision worth reviewing: detection, not a flag

A project's runtime is **not stable over its lifetime**. Pausing terminates the instance; restoring provisions a fresh one from whatever AMI is current. A project created on AL2023 + compose can legitimately come back on Ubuntu + podman, with nothing about the project itself having changed. Any runtime marker stored in the control plane (a DB column, a per-project branch) is a second source of truth that drifts from reality exactly then — and the failure mode is silent: docker-compose commands sent to a podman host.

So the instance describes itself. `insforge-ctl` detects the local runtime and exposes one vocabulary over both:

```
insforge-ctl runtime|status|up|down|restart|stop-apps|start-all|upgrade <ver>|prune|psql|pg_dump
```

Callers use verbs and never branch on runtime. And because the control plane's restart/upgrade sequences already `git pull` this repo, **existing instances acquire the script on their next operation** — no fleet sweep needed.

## Files

- `insforge-ctl` — the runtime-agnostic verb surface (both runtimes)
- `systemd/*.container`, `systemd/insforge.network` — quadlet units
- `systemd/insforge-render-env` — `.env` → per-service env files + secrets drop-in + limit drop-ins
- `systemd/README.md` — the constraints below, written down where the next editor will find them

## Two constraints found the hard way (documented in the README)

1. **Container DNS names are container names, not compose service aliases.** The app connects to `postgres:5432`, but quadlet registers `insforge-postgres`. Without `--network-alias=postgres` the app cannot resolve its database and crash-loops through migrations — 47 restarts before I spotted it.
2. **Multi-line values cannot travel in an env file.** `AWS_CLOUDFRONT_PRIVATE_KEY` is a PEM; neither systemd's `EnvironmentFile=` nor podman's `--env-file` parses embedded newlines. The render script writes it as a systemd `Environment="KEY=…\n…"` drop-in and the unit inherits it via a valueless `-e`. Verified byte-for-byte inside the container (1703 bytes host → identical in container).

Also: quadlet units cannot be `systemctl enable`d ("transient or generated") — boot start comes from `[Install]` inside the `.container`; and podman 4.9 has no `Notify=healthy`, so dependents gate on an `ExecStartPre` `pg_isready` loop until podman 5.0.

## Verified on a live t4g.nano

AMI baked (Ubuntu 24.04 + podman 4.9.3 + deb SSM agent + trimmed services), stack brought up, then: reboot drill with automatic recovery of all three units; fluent-bit delivering to the existing `*-vector` CloudWatch streams unchanged; OSS E2E suite 9/15 with **every failure triaged to a pre-existing or environmental cause, none runtime-attributable** (the two storage failures reproduce identically on a docker instance); and each `insforge-ctl` verb exercised — `restart` completes in 5.3s with health 200, `psql`/`pg_dump` work against the host-side client, drop-ins generated correctly.

## Follow-up (separate PR, cloud-backend)

user-data variant that installs this profile, the AMI id wired per region, and the command generators switched to `insforge-ctl` with an inline fallback to the legacy commands so old, new, and mid-migration instances all work from one command string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Ubuntu 24.04 + `podman` runtime profile with `quadlet` units and a runtime-agnostic `insforge-ctl`, cutting t4g.nano memory to ~158MB while keeping control-plane commands the same. Existing instances stay unchanged until the new AMI is launched; a reproducible Ubuntu AMI bake script is now included.

- **New Features**
  - `insforge-ctl`: detects local runtime (`podman` or `compose`, including the Docker Compose V2 plugin) and provides shared verbs: `runtime|up|down|restart|restart-app|stop-apps|start-all|upgrade <ver>|prune|psql|pg_dump|status`.
  - Quadlet units for `insforge-postgres`, `insforge-postgrest`, and `insforge`, with network aliases (`postgres`, `postgrest`) and DB readiness gating.
  - `insforge-render-env`: generates per-service env files, injects the CloudFront PEM via a systemd drop-in, writes memory cgroup limits from `.env`, and stamps per-tier server params into unit Exec lines (PG `max_connections`, `app.encryption_key`, PostgREST RTS heap).
  - `provisioning/ubuntu-bake.sh`: Ubuntu AMI bake script that installs required tooling, configures zram, trims services, and sets up logging/metrics for the podman profile.

- **Bug Fixes**
  - `restart`/`up` now re-install quadlet units and re-derive the app image from `.env` (`INSFORGE_OSS_VER`) so unit changes and version bumps take effect; added `restart-app` to restart only the app.
  - Defaulted the `insforge` quadlet image to `v2.3.0` to match `docker-compose.yml`; provisioning and `insforge-ctl upgrade <ver>` still override this line.
  - `insforge-ctl` self-elevates on `podman` by re-execing the root-owned `/usr/local/bin/insforge-ctl`, so callers don’t need `sudo` and the compose path remains non-root.
  - Per-tier/runtime fixes: removed CPU quotas (keep memory limits with `MemoryHigh`), added `POSTGREST_MAX_SOCKETS`, and tightened env rendering to avoid junk vars while handling the PEM safely.
  - Bake script fixes: install AWS CLI v2 via the vendor installer (not `apt`), ensure `unzip` is present, and add post-boot checks to catch missing tooling early.

<sup>Written for commit 8c5da5fb89ca269b41324c15ed142ecb474edc7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `insforge-ctl`, a command-line tool for managing deployments with Podman or Docker Compose.
  * Added lifecycle controls, application-only restarts, upgrades, cleanup, database access, status reporting, and runtime detection.
  * Added a Podman deployment profile with persistent PostgreSQL storage, automatic restarts, health checks, resource limits, and service readiness checks.
  * Added secure environment generation, including support for multiline certificates and private keys.

* **Documentation**
  * Added setup and operational guidance for Ubuntu 24.04 with Podman and systemd.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->