### PR TITLE
Ubuntu/podman runtime profile: quadlet units + insforge-ctl

### DIFF
--- a/insforge-ctl
+++ b/insforge-ctl
@@ -143,7 +143,15 @@ sync_units() {
       /etc/containers/systemd/insforge.container
     podman pull "ghcr.io/insforge/insforge-oss:${ver}" >/dev/null 2>&1 || true
   fi
-  systemctl daemon-reload
+  # Deliberately no daemon-reload here. Every caller runs
+  # sync_units -> insforge-render-env -> daemon-reload, and reloading in the
+  # middle would regenerate the service from the freshly installed *unstamped*
+  # postgres unit. If the render then aborted, the generated unit would be left
+  # without app.encryption_key — and because the units are
+  # WantedBy=multi-user.target, the next reboot starts postgres directly rather
+  # than through this script, so it would come up keyless and only fail later at
+  # decrypt time. Reloading once, after the stamping, means a failed render
+  # leaves the previous generated units in place instead.
 }
 
 usage() {

--- a/insforge-ctl
+++ b/insforge-ctl
@@ -14,7 +14,6 @@
 set -euo pipefail
 
 PROJECT_DIR=${INSFORGE_PROJECT_DIR:-/home/ec2-user/insforge-standalone}
-COMPOSE_FILE="$PROJECT_DIR/docker-compose.yml"
 QUADLET_MARKER=/etc/containers/systemd/insforge-postgres.container
 APP_UNITS=(insforge-postgres insforge-postgrest insforge)
 
@@ -109,7 +108,9 @@ warn_if_locally_modified() {
   local as_owner=(git -C "$PROJECT_DIR")
   [ "$(id -u)" = 0 ] && [ "$owner" != root ] && as_owner=(sudo -n -u "$owner" git -C "$PROJECT_DIR")
   "${as_owner[@]}" rev-parse --git-dir >/dev/null 2>&1 || return 0
-  "${as_owner[@]}" diff --quiet HEAD -- systemd insforge-ctl 2>/dev/null && return 0
+  # --untracked-files=all, because `git diff` does not report a file that was
+  # never added — an untracked systemd/*.container would install silently.
+  [ -z "$("${as_owner[@]}" status --porcelain --untracked-files=all -- systemd insforge-ctl 2>/dev/null)" ] && return 0
   echo "warning: $PROJECT_DIR has uncommitted changes under systemd/ or insforge-ctl;" \
        "installing them as root anyway" >&2
 }

--- a/insforge-ctl
+++ b/insforge-ctl
@@ -42,7 +42,7 @@ RUNTIME=$(detect_runtime)
 # Why the installed copy rather than a sudoers rule over the checkout: it gives
 # the rule one stable path that exists even when the checkout is mid-`git pull`
 # or missing. Being explicit, since an earlier version of this comment claimed
-# more: it is NOT an immutability guarantee — sync_units below refreshes this
+# more: it is NOT an immutability guarantee — sync_and_render below refreshes this
 # file from that same checkout, and it has to, or a fix to this script could
 # never reach an existing instance. On a project instance that costs nothing,
 # because SSM runs commands as root and the control plane drops to ec2-user by
@@ -92,7 +92,7 @@ load_env() {
 # already root.
 #
 # So this warns rather than refusing. A hard failure here would be worse than
-# what it prevents: sync_units is what makes a version bump take effect, the
+# what it prevents: sync_and_render is what makes a version bump take effect, the
 # callers below do not check its status, and making it fatal would break every
 # restart on an instance someone hand-patched during an incident. The warning
 # lands in the SSM output and the journal, which is what actually makes an
@@ -115,43 +115,72 @@ warn_if_locally_modified() {
        "installing them as root anyway" >&2
 }
 
-sync_units() {
-  [ "$RUNTIME" = podman ] || return 0
+# Install the units and render them into place as one operation, staging first.
+#
+# The staging matters. Quadlet regenerates the service units from
+# /etc/containers/systemd/*.container on every boot, so the file on disk — not
+# the generated unit in /run — is what survives a reboot. Installing the repo's
+# unstamped postgres unit there and only afterwards stamping app.encryption_key
+# into it leaves a window: if the render aborts, the next boot regenerates from
+# the unstamped file and Postgres comes up with no encryption key, failing later
+# at decrypt time rather than at start. Skipping the daemon-reload does not help,
+# because boot does not need one.
+#
+# So: install into a staging dir, render against that (insforge-render-env takes
+# QUADLET_DIR), and only move the results into place once the render succeeded.
+# A failed render leaves the previous, stamped units untouched.
+sync_and_render() {
+  if [ "$RUNTIME" != podman ]; then
+    return 0
+  fi
   local src="$PROJECT_DIR/systemd"
-  [ -d "$src" ] || return 0
+  local stage=/run/insforge/quadlet-staging
+  local live=/etc/containers/systemd
+
+  # Even with no repo checkout to sync from, the env files still have to be
+  # rendered — .env may have changed without the units having.
+  if [ ! -d "$src" ]; then
+    /usr/local/bin/insforge-render-env
+    systemctl daemon-reload
+    return 0
+  fi
+
   warn_if_locally_modified
-  # The postgres unit carries app.encryption_key on its Exec line (a server
-  # start parameter cannot come from an EnvironmentFile), so it is installed
-  # 0600 rather than 0644 like the units that hold no secret. Quadlet generates
-  # as root and reads it fine.
-  install -m 0644 "$src"/*.network /etc/containers/systemd/ 2>/dev/null || true
-  install -m 0644 "$src/insforge.container" "$src/insforge-postgrest.container" \
-    /etc/containers/systemd/ 2>/dev/null || true
-  install -m 0600 "$src/insforge-postgres.container" /etc/containers/systemd/ 2>/dev/null || true
   install -m 0755 "$src/insforge-render-env" /usr/local/bin/insforge-render-env 2>/dev/null || true
   # Refresh the root-owned copy of this script too. Without this it stays frozen
   # at whatever provisioning installed: the elevated process is
   # /usr/local/bin/insforge-ctl, so a fix delivered by `git pull` would never run
-  # on an existing instance — the same silent no-op this function exists to
-  # prevent for units and image tags. Replacing the file under a running process
-  # is safe (the old inode stays open); it takes effect on the next invocation.
+  # on an existing instance. Replacing the file under a running process is safe
+  # (the old inode stays open); it takes effect on the next invocation.
   install -m 0755 "$PROJECT_DIR/insforge-ctl" "$INSTALLED_CTL" 2>/dev/null || true
+
+  rm -rf "$stage"
+  mkdir -p "$stage"
+  # The postgres unit ends up carrying app.encryption_key on its Exec line (a
+  # server start parameter cannot come from an EnvironmentFile), so it is 0600
+  # rather than 0644 like the units that hold no secret. Quadlet generates as
+  # root and reads it fine.
+  install -m 0644 "$src"/*.network "$stage"/
+  install -m 0644 "$src/insforge.container" "$src/insforge-postgrest.container" "$stage"/
+  install -m 0600 "$src/insforge-postgres.container" "$stage"/
+
   local ver
   ver=$(grep -E '^INSFORGE_OSS_VER=' "$PROJECT_DIR/.env" 2>/dev/null | cut -d= -f2)
   if [ -n "$ver" ]; then
     sed -i "s|^Image=ghcr.io/insforge/insforge-oss:.*|Image=ghcr.io/insforge/insforge-oss:${ver}|" \
-      /etc/containers/systemd/insforge.container
+      "$stage/insforge.container"
     podman pull "ghcr.io/insforge/insforge-oss:${ver}" >/dev/null 2>&1 || true
   fi
-  # Deliberately no daemon-reload here. Every caller runs
-  # sync_units -> insforge-render-env -> daemon-reload, and reloading in the
-  # middle would regenerate the service from the freshly installed *unstamped*
-  # postgres unit. If the render then aborted, the generated unit would be left
-  # without app.encryption_key — and because the units are
-  # WantedBy=multi-user.target, the next reboot starts postgres directly rather
-  # than through this script, so it would come up keyless and only fail later at
-  # decrypt time. Reloading once, after the stamping, means a failed render
-  # leaves the previous generated units in place instead.
+
+  # Stamps the staged units and writes the env files / drop-ins. set -e aborts
+  # here on failure, before anything reaches $live.
+  QUADLET_DIR="$stage" /usr/local/bin/insforge-render-env
+
+  install -m 0644 "$stage"/*.network "$live"/
+  install -m 0644 "$stage/insforge.container" "$stage/insforge-postgrest.container" "$live"/
+  install -m 0600 "$stage/insforge-postgres.container" "$live"/
+  rm -rf "$stage"
+  systemctl daemon-reload
 }
 
 usage() {
@@ -184,9 +213,7 @@ case "$verb" in
 
   up)
     if [ "$RUNTIME" = podman ]; then
-      sync_units
-      /usr/local/bin/insforge-render-env
-      systemctl daemon-reload
+      sync_and_render
       systemctl start "${APP_UNITS[@]}"
     else
       compose up -d
@@ -207,9 +234,7 @@ case "$verb" in
       # plane appends keys to .env and rewrites INSFORGE_OSS_VER, and expects a
       # restart to pick both up — implicit under compose, which re-read .env
       # and the compose file on every `up`.
-      sync_units
-      /usr/local/bin/insforge-render-env
-      systemctl daemon-reload
+      sync_and_render
       systemctl restart "${APP_UNITS[@]}"
     else
       compose down
@@ -221,9 +246,7 @@ case "$verb" in
     # App only. The reserved-secrets reset needs the app to re-read its
     # secrets without bouncing Postgres, which a full-stack restart would do.
     if [ "$RUNTIME" = podman ]; then
-      sync_units
-      /usr/local/bin/insforge-render-env
-      systemctl daemon-reload
+      sync_and_render
       systemctl restart insforge
     else
       compose restart insforge

--- a/insforge-ctl
+++ b/insforge-ctl
@@ -1,0 +1,245 @@
+#!/bin/bash
+# insforge-ctl — runtime-agnostic control surface for a project instance.
+#
+# Why this exists: the fleet runs two container runtimes during the migration
+# (AL2023 + docker-compose, and Ubuntu + podman/quadlet), and an instance can
+# switch from one to the other without warning — a paused project's restore
+# provisions a brand-new instance from whatever AMI is current, so a project
+# created under compose can come back under podman. Encoding the runtime in
+# the control plane (a DB flag, a per-project branch) means two sources of
+# truth that eventually disagree. Instead the instance reports what it is:
+# every caller runs the same verbs here and this script picks the mechanism.
+#
+# Callers: the cloud control plane over SSM, and the backup/restore scripts.
+set -euo pipefail
+
+PROJECT_DIR=${INSFORGE_PROJECT_DIR:-/home/ec2-user/insforge-standalone}
+COMPOSE_FILE="$PROJECT_DIR/docker-compose.yml"
+QUADLET_MARKER=/etc/containers/systemd/insforge-postgres.container
+APP_UNITS=(insforge-postgres insforge-postgrest insforge)
+
+detect_runtime() {
+  if [ -f "$QUADLET_MARKER" ] && command -v podman >/dev/null 2>&1; then
+    echo podman
+  elif command -v docker-compose >/dev/null 2>&1; then
+    echo compose
+  elif command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    # Compose V2 plugin only (no `docker-compose` shim). The current fleet is
+    # all V1, but detecting `compose` and then calling a binary that does not
+    # exist would fail every verb, so pick the form that is actually present.
+    echo compose-v2
+  else
+    echo "insforge-ctl: no container runtime detected" >&2
+    exit 1
+  fi
+}
+RUNTIME=$(detect_runtime)
+
+# Self-elevate for podman. systemctl/podman need root, but the control plane
+# runs instance commands as ec2-user. Callers therefore invoke this script
+# plainly (no sudo) and it re-execs the *installed, root-owned* copy under a
+# narrowly scoped sudoers rule.
+#
+# Why not let callers sudo this file directly: the repo checkout is owned by
+# ec2-user and updated by `git pull`, so a sudoers rule covering it would let
+# ec2-user rewrite the script and run arbitrary code as root -- blanket root
+# with extra steps. Only /usr/local/bin/insforge-ctl is root-owned, so only it
+# is safe to grant. The compose path needs no elevation at all (docker runs via
+# the docker group), which is why this is podman-only.
+INSTALLED_CTL=/usr/local/bin/insforge-ctl
+if [ "$RUNTIME" = podman ] && [ "$(id -u)" != 0 ]; then
+  [ -x "$INSTALLED_CTL" ] || {
+    echo "insforge-ctl: podman needs root and $INSTALLED_CTL is not installed" >&2
+    exit 1
+  }
+  exec sudo -n "$INSTALLED_CTL" "$@"
+fi
+
+compose() {
+  if [ "$RUNTIME" = compose-v2 ]; then
+    (cd "$PROJECT_DIR" && docker compose "$@")
+  else
+    (cd "$PROJECT_DIR" && docker-compose "$@")
+  fi
+}
+
+# Load .env for the DB credentials used by the psql/pg_dump verbs.
+load_env() {
+  set -a
+  # shellcheck disable=SC1091
+  source "$PROJECT_DIR/.env"
+  set +a
+  PGUSER_="${POSTGRES_USER:-postgres}"
+  PGDB_="${POSTGRES_DB:-insforge}"
+  PGPASS_="${POSTGRES_PASSWORD:-postgres}"
+}
+
+# Re-install the quadlet units from the repo and re-derive the app image tag
+# from .env. Both matter because the control plane's flows assume compose
+# semantics: `git pull` then restart deployed a changed compose file, and
+# rewriting INSFORGE_OSS_VER in .env then restarting changed the image. Under
+# quadlet the units live in /etc/containers/systemd and the tag lives inside
+# insforge.container, so without this a unit change or a version bump silently
+# no-ops on podman.
+sync_units() {
+  [ "$RUNTIME" = podman ] || return 0
+  local src="$PROJECT_DIR/systemd"
+  [ -d "$src" ] || return 0
+  install -m 0644 "$src"/*.container "$src"/*.network /etc/containers/systemd/ 2>/dev/null || true
+  install -m 0755 "$src/insforge-render-env" /usr/local/bin/insforge-render-env 2>/dev/null || true
+  local ver
+  ver=$(grep -E '^INSFORGE_OSS_VER=' "$PROJECT_DIR/.env" 2>/dev/null | cut -d= -f2)
+  if [ -n "$ver" ]; then
+    sed -i "s|^Image=ghcr.io/insforge/insforge-oss:.*|Image=ghcr.io/insforge/insforge-oss:${ver}|" \
+      /etc/containers/systemd/insforge.container
+    podman pull "ghcr.io/insforge/insforge-oss:${ver}" >/dev/null 2>&1 || true
+  fi
+  systemctl daemon-reload
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: insforge-ctl <verb> [args]
+
+  runtime              print the detected runtime (podman|compose)
+  up                   start the whole stack
+  down                 stop the whole stack
+  restart              restart the whole stack (re-syncs units/env first on podman)
+  restart-app          restart only the app container, leaving Postgres up
+  stop-apps            stop insforge + postgrest, leave postgres running
+  start-all            start everything (used after stop-apps)
+  upgrade <version>    switch the app image tag and restart
+  prune                reclaim unused image/layer storage
+  psql [args...]       run psql against the project DB (stdin passthrough)
+  pg_dump [args...]    run pg_dump against the project DB (stdout passthrough)
+  status               one line per service
+USAGE
+  exit 64
+}
+
+[ $# -ge 1 ] || usage
+verb=$1; shift || true
+
+case "$verb" in
+  runtime)
+    echo "$RUNTIME"
+    ;;
+
+  up)
+    if [ "$RUNTIME" = podman ]; then
+      sync_units
+      /usr/local/bin/insforge-render-env
+      systemctl daemon-reload
+      systemctl start "${APP_UNITS[@]}"
+    else
+      compose up -d
+    fi
+    ;;
+
+  down)
+    if [ "$RUNTIME" = podman ]; then
+      systemctl stop "${APP_UNITS[@]}" || true
+    else
+      compose down
+    fi
+    ;;
+
+  restart)
+    if [ "$RUNTIME" = podman ]; then
+      # Re-sync units and the image tag, then re-render env: the control
+      # plane appends keys to .env and rewrites INSFORGE_OSS_VER, and expects a
+      # restart to pick both up — implicit under compose, which re-read .env
+      # and the compose file on every `up`.
+      sync_units
+      /usr/local/bin/insforge-render-env
+      systemctl daemon-reload
+      systemctl restart "${APP_UNITS[@]}"
+    else
+      compose down
+      compose up -d
+    fi
+    ;;
+
+  restart-app)
+    # App only. The reserved-secrets reset needs the app to re-read its
+    # secrets without bouncing Postgres, which a full-stack restart would do.
+    if [ "$RUNTIME" = podman ]; then
+      sync_units
+      /usr/local/bin/insforge-render-env
+      systemctl daemon-reload
+      systemctl restart insforge
+    else
+      compose restart insforge
+    fi
+    ;;
+
+  stop-apps)
+    if [ "$RUNTIME" = podman ]; then
+      systemctl stop insforge insforge-postgrest || true
+    else
+      compose stop insforge postgrest
+    fi
+    ;;
+
+  start-all)
+    "$0" up
+    ;;
+
+  upgrade)
+    [ $# -ge 1 ] || usage
+    version=$1
+    sed -i "s|^INSFORGE_OSS_VER=.*|INSFORGE_OSS_VER=${version}|" "$PROJECT_DIR/.env"
+    if [ "$RUNTIME" = podman ]; then
+      sed -i "s|^Image=ghcr.io/insforge/insforge-oss:.*|Image=ghcr.io/insforge/insforge-oss:${version}|" \
+        /etc/containers/systemd/insforge.container
+      podman pull "ghcr.io/insforge/insforge-oss:${version}"
+      /usr/local/bin/insforge-render-env
+      systemctl daemon-reload
+      systemctl restart insforge
+    else
+      compose pull insforge
+      compose up -d
+    fi
+    ;;
+
+  prune)
+    if [ "$RUNTIME" = podman ]; then
+      podman system prune -a -f
+    else
+      docker system prune -a -f
+    fi
+    ;;
+
+  # psql/pg_dump: on podman the host has a postgresql client and the server
+  # listens on 127.0.0.1, so no container round-trip is needed. On compose we
+  # keep going through the container because the AL2023 host has no client.
+  psql)
+    load_env
+    if [ "$RUNTIME" = podman ]; then
+      PGPASSWORD="$PGPASS_" psql -h 127.0.0.1 -U "$PGUSER_" -d "$PGDB_" "$@"
+    else
+      compose exec -T postgres env PGPASSWORD="$PGPASS_" psql -U "$PGUSER_" -d "$PGDB_" "$@"
+    fi
+    ;;
+
+  pg_dump)
+    load_env
+    if [ "$RUNTIME" = podman ]; then
+      PGPASSWORD="$PGPASS_" pg_dump -h 127.0.0.1 -U "$PGUSER_" "$@" "$PGDB_"
+    else
+      compose exec -T postgres env PGPASSWORD="$PGPASS_" pg_dump -U "$PGUSER_" "$@" "$PGDB_"
+    fi
+    ;;
+
+  status)
+    if [ "$RUNTIME" = podman ]; then
+      for u in "${APP_UNITS[@]}"; do echo "$u: $(systemctl is-active "$u")"; done
+    else
+      compose ps --format '{{.Name}}: {{.State}}' 2>/dev/null || compose ps
+    fi
+    ;;
+
+  *)
+    usage
+    ;;
+esac

--- a/insforge-ctl
+++ b/insforge-ctl
@@ -123,6 +123,13 @@ sync_units() {
     /etc/containers/systemd/ 2>/dev/null || true
   install -m 0600 "$src/insforge-postgres.container" /etc/containers/systemd/ 2>/dev/null || true
   install -m 0755 "$src/insforge-render-env" /usr/local/bin/insforge-render-env 2>/dev/null || true
+  # Refresh the root-owned copy of this script too. Without this it stays frozen
+  # at whatever provisioning installed: the elevated process is
+  # /usr/local/bin/insforge-ctl, so a fix delivered by `git pull` would never run
+  # on an existing instance — the same silent no-op this function exists to
+  # prevent for units and image tags. Replacing the file under a running process
+  # is safe (the old inode stays open); it takes effect on the next invocation.
+  install -m 0755 "$PROJECT_DIR/insforge-ctl" "$INSTALLED_CTL" 2>/dev/null || true
   local ver
   ver=$(grep -E '^INSFORGE_OSS_VER=' "$PROJECT_DIR/.env" 2>/dev/null | cut -d= -f2)
   if [ -n "$ver" ]; then

--- a/insforge-ctl
+++ b/insforge-ctl
@@ -81,11 +81,47 @@ load_env() {
 # quadlet the units live in /etc/containers/systemd and the tag lives inside
 # insforge.container, so without this a unit change or a version bump silently
 # no-ops on podman.
+# These files come from a checkout ec2-user can write, and root installs and
+# then executes them. That is worth naming, but it is not a privilege boundary
+# being crossed on a project instance: SSM runs commands as root and the control
+# plane drops to ec2-user by choice, so anything that can act as ec2-user here is
+# already root.
+#
+# So this warns rather than refusing. A hard failure here would be worse than
+# what it prevents: sync_units is what makes a version bump take effect, the
+# callers below do not check its status, and making it fatal would break every
+# restart on an instance someone hand-patched during an incident. The warning
+# lands in the SSM output and the journal, which is what actually makes an
+# unexpected edit visible.
+# git as root on a checkout owned by someone else refuses outright ("dubious
+# ownership", exit 128), so this has to drop to the owner to get an answer.
+# Overriding that with `-c safe.directory` would be the wrong fix: a repo-local
+# git config would then run commands as root, which is the exact shape of the
+# problem this check is about. Only the exit status is consumed.
+warn_if_locally_modified() {
+  local owner
+  owner=$(stat -c %U "$PROJECT_DIR" 2>/dev/null) || return 0
+  local as_owner=(git -C "$PROJECT_DIR")
+  [ "$(id -u)" = 0 ] && [ "$owner" != root ] && as_owner=(sudo -n -u "$owner" git -C "$PROJECT_DIR")
+  "${as_owner[@]}" rev-parse --git-dir >/dev/null 2>&1 || return 0
+  "${as_owner[@]}" diff --quiet HEAD -- systemd insforge-ctl 2>/dev/null && return 0
+  echo "warning: $PROJECT_DIR has uncommitted changes under systemd/ or insforge-ctl;" \
+       "installing them as root anyway" >&2
+}
+
 sync_units() {
   [ "$RUNTIME" = podman ] || return 0
   local src="$PROJECT_DIR/systemd"
   [ -d "$src" ] || return 0
-  install -m 0644 "$src"/*.container "$src"/*.network /etc/containers/systemd/ 2>/dev/null || true
+  warn_if_locally_modified
+  # The postgres unit carries app.encryption_key on its Exec line (a server
+  # start parameter cannot come from an EnvironmentFile), so it is installed
+  # 0600 rather than 0644 like the units that hold no secret. Quadlet generates
+  # as root and reads it fine.
+  install -m 0644 "$src"/*.network /etc/containers/systemd/ 2>/dev/null || true
+  install -m 0644 "$src/insforge.container" "$src/insforge-postgrest.container" \
+    /etc/containers/systemd/ 2>/dev/null || true
+  install -m 0600 "$src/insforge-postgres.container" /etc/containers/systemd/ 2>/dev/null || true
   install -m 0755 "$src/insforge-render-env" /usr/local/bin/insforge-render-env 2>/dev/null || true
   local ver
   ver=$(grep -E '^INSFORGE_OSS_VER=' "$PROJECT_DIR/.env" 2>/dev/null | cut -d= -f2)

--- a/insforge-ctl
+++ b/insforge-ctl
@@ -40,12 +40,17 @@ RUNTIME=$(detect_runtime)
 # plainly (no sudo) and it re-execs the *installed, root-owned* copy under a
 # narrowly scoped sudoers rule.
 #
-# Why not let callers sudo this file directly: the repo checkout is owned by
-# ec2-user and updated by `git pull`, so a sudoers rule covering it would let
-# ec2-user rewrite the script and run arbitrary code as root -- blanket root
-# with extra steps. Only /usr/local/bin/insforge-ctl is root-owned, so only it
-# is safe to grant. The compose path needs no elevation at all (docker runs via
-# the docker group), which is why this is podman-only.
+# Why the installed copy rather than a sudoers rule over the checkout: it gives
+# the rule one stable path that exists even when the checkout is mid-`git pull`
+# or missing. Being explicit, since an earlier version of this comment claimed
+# more: it is NOT an immutability guarantee — sync_units below refreshes this
+# file from that same checkout, and it has to, or a fix to this script could
+# never reach an existing instance. On a project instance that costs nothing,
+# because SSM runs commands as root and the control plane drops to ec2-user by
+# choice: anything that can act as ec2-user here is already root.
+#
+# The compose path needs no elevation at all (docker runs via the docker group),
+# which is why this is podman-only.
 INSTALLED_CTL=/usr/local/bin/insforge-ctl
 if [ "$RUNTIME" = podman ] && [ "$(id -u)" != 0 ]; then
   [ -x "$INSTALLED_CTL" ] || {
@@ -144,7 +149,7 @@ usage() {
   cat >&2 <<'USAGE'
 usage: insforge-ctl <verb> [args]
 
-  runtime              print the detected runtime (podman|compose)
+  runtime              print the detected runtime (podman|compose|compose-v2)
   up                   start the whole stack
   down                 stop the whole stack
   restart              restart the whole stack (re-syncs units/env first on podman)

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -81,6 +81,13 @@ into a provision with the instance already terminated by the rollback.
   crippling under load — the hardest kind of regression to attribute later.
 - `insforge-render-env` runs on every `insforge-ctl restart`, so appending a
   key to `.env` and restarting behaves the way it did under compose.
+- `sync_units` also refreshes `/usr/local/bin/insforge-ctl` from the checkout,
+  because the elevated process *is* that copy — without it, a fix to this script
+  delivered by `git pull` would never run on an existing instance. Note the
+  bootstrap: the refresh can only happen from a version that already contains it,
+  so an instance whose installed copy predates this stays on the old one until it
+  is replaced. That is fine today because no instance is on podman in production
+  yet; every one will be provisioned with this version by `podman.sh`.
 - `insforge-postgres.container` is installed `0600`, not `0644` like the other
   units: `app.encryption_key` is a server start parameter, so it cannot come
   from an `EnvironmentFile` and ends up on the unit's `Exec` line.

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -43,6 +43,26 @@ the unit passes it through with a valueless `-e AWS_CLOUDFRONT_PRIVATE_KEY`,
 which tells podman to inherit it from the process environment. Verified
 byte-for-byte inside the container.
 
+## What the image has to provide
+
+These units are not self-contained — they assume the host image already has
+certain things, and each assumption has bitten once. The bake script lives in
+insforge-cloud-backend (`config/ami/ubuntu-bake.sh`) because the AMI is only
+consumed by that control plane, so this is the contract it has to satisfy:
+
+| Requirement | Why |
+|---|---|
+| podman ≥ 4.9 with quadlet | These are quadlet `.container` files; quadlet is what generates the units |
+| `overlay` storage driver, not `fuse-overlayfs` | fuse-overlayfs adds a userspace daemon per layer stack — the exact overhead this migration exists to remove |
+| `postgresql-client` major **16** | `insforge-ctl psql`/`pg_dump` run on the host against the container. pg_dump 17+ emits settings a 15 server rejects, so the client major is pinned deliberately |
+| AWS CLI v2 **and** `unzip` | The S3 backup/restore helpers and the SSM-association wait shell out to `aws`. Provisioning installs the CLI if absent, and needs unzip to unpack it — an image with neither killed provisioning three times |
+| SSM agent from the **deb**, not snap | Removing the snap agent kills the process executing the user-data script, so the swap only works at bake time |
+| `systemd-zram-generator`, `zram-size = ram` | Swap is how a nano survives; installing the generator creates zram0 at ram/2 immediately and the config only takes effect on the next boot |
+
+Anything the units or `insforge-ctl` start depending on has to be added there
+and asserted in that script's post-boot checklist, not discovered at 20 seconds
+into a provision with the instance already terminated by the rollback.
+
 ## Other things worth knowing before editing these
 
 - Quadlet-generated units **cannot** be `systemctl enable`d ("transient or

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -73,8 +73,29 @@ into a provision with the instance already terminated by the rollback.
   than on the container's health status. `Notify=healthy` lands in podman 5.0
   and this can be simplified then.
 - Resource limits are cgroup settings on the units, written by
-  `insforge-render-env` from the `*_MEMORY` / `*_CPUS` values that
-  `auto-scale-memory.sh` puts in `.env` — not `PodmanArgs`. This buys
-  `MemoryHigh` (throttle before the OOM killer), which compose could not express.
+  `insforge-render-env` from the `*_MEMORY` values that `auto-scale-memory.sh`
+  puts in `.env` — not `PodmanArgs`. This buys `MemoryHigh` (throttle before the
+  OOM killer), which compose could not express. **Memory only: no `CPUQuota`.**
+  `auto-scale-memory.sh` strips `*_CPUS`, so any default quota would always be
+  the one in force, and a percentage cap on a nano is invisible at idle and
+  crippling under load — the hardest kind of regression to attribute later.
 - `insforge-render-env` runs on every `insforge-ctl restart`, so appending a
   key to `.env` and restarting behaves the way it did under compose.
+- `insforge-postgres.container` is installed `0600`, not `0644` like the other
+  units: `app.encryption_key` is a server start parameter, so it cannot come
+  from an `EnvironmentFile` and ends up on the unit's `Exec` line.
+- `insforge-ctl` installs these files as root from a checkout `ec2-user` can
+  write, and then executes `insforge-render-env` as root. Worth naming, but it is
+  not a boundary being crossed: SSM runs commands as root and the control plane
+  drops to `ec2-user` by choice, so anything that can act as `ec2-user` on a
+  project instance is already root. Note this also means the root-owned copy at
+  `/usr/local/bin` is not a protection — `sync_units` overwrites it from the
+  checkout on every restart. Its purpose is a stable path for one sudoers rule,
+  not immutability.
+- `sync_units` therefore **warns** about uncommitted changes under `systemd/` or
+  `insforge-ctl` and installs them anyway. Refusing would be worse than what it
+  prevents: `sync_units` is what makes a version bump take effect, its callers do
+  not check its status, so a refusal would silently skip the sync — and making it
+  fatal would break every restart on an instance someone hand-patched during an
+  incident. The warning reaches the SSM output and the journal, which is what
+  makes an unexpected edit visible.

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,60 @@
+# Podman / quadlet runtime profile
+
+The Ubuntu 24.04 + podman variant of a project instance. Selected by which AMI
+the control plane launches; nothing in the control plane needs to know which
+one it got, because every operation goes through `insforge-ctl`, which detects
+the runtime on the instance itself.
+
+## Why detection instead of a flag
+
+A project's runtime is not stable over its lifetime. Pausing terminates the
+instance and restoring provisions a fresh one from whatever AMI is current, so
+a project created on AL2023 + docker-compose can legitimately come back on
+Ubuntu + podman with no change to the project itself. Any runtime marker
+stored in the control plane is a second source of truth that drifts from the
+instance the moment that happens. `insforge-ctl runtime` asks the machine.
+
+## Files
+
+| File | Installed to | Purpose |
+|---|---|---|
+| `insforge.network` | `/etc/containers/systemd/` | Bridge network for the three services |
+| `insforge-postgres.container` | `/etc/containers/systemd/` | Postgres; `--network-alias=postgres` |
+| `insforge-postgrest.container` | `/etc/containers/systemd/` | PostgREST; `--network-alias=postgrest` |
+| `insforge.container` | `/etc/containers/systemd/` | App; inherits the CloudFront PEM via `-e` |
+| `insforge-render-env` | `/usr/local/bin/` | `.env` → per-service env files, secrets drop-in, limit drop-ins |
+
+`../insforge-ctl` → `/usr/local/bin/insforge-ctl` (shared by both runtimes).
+
+## Two non-obvious constraints, both learned the hard way
+
+**Container DNS names are container names, not compose service aliases.** The
+app connects to `postgres:5432` and PostgREST to `postgres`, but quadlet
+registers the container as `insforge-postgres`. Without
+`PodmanArgs=--network-alias=postgres` the app cannot resolve its database and
+crash-loops through migrations. Same for `postgrest`.
+
+**Multi-line values cannot travel in an env file.** `AWS_CLOUDFRONT_PRIVATE_KEY`
+is a PEM; neither systemd's `EnvironmentFile=` nor podman's `--env-file` parses
+a value containing newlines. `insforge-render-env` writes it into
+`/etc/systemd/system/insforge.service.d/secrets.conf` as a systemd
+`Environment="KEY=…\n…"` string (systemd unescapes `\n` in quoted values), and
+the unit passes it through with a valueless `-e AWS_CLOUDFRONT_PRIVATE_KEY`,
+which tells podman to inherit it from the process environment. Verified
+byte-for-byte inside the container.
+
+## Other things worth knowing before editing these
+
+- Quadlet-generated units **cannot** be `systemctl enable`d ("transient or
+  generated"). Boot start comes from `[Install] WantedBy=` inside the
+  `.container` file, which quadlet honours at generation time.
+- podman 4.9 (what Ubuntu 24.04 ships) has no `Notify=healthy`, so dependent
+  units gate on the database with an `ExecStartPre` `pg_isready` loop rather
+  than on the container's health status. `Notify=healthy` lands in podman 5.0
+  and this can be simplified then.
+- Resource limits are cgroup settings on the units, written by
+  `insforge-render-env` from the `*_MEMORY` / `*_CPUS` values that
+  `auto-scale-memory.sh` puts in `.env` — not `PodmanArgs`. This buys
+  `MemoryHigh` (throttle before the OOM killer), which compose could not express.
+- `insforge-render-env` runs on every `insforge-ctl restart`, so appending a
+  key to `.env` and restarting behaves the way it did under compose.

--- a/systemd/insforge-postgres.container
+++ b/systemd/insforge-postgres.container
@@ -14,13 +14,19 @@ Volume=/home/ec2-user/insforge-standalone/docker-init/db/jwt.sql:/docker-entrypo
 Volume=/home/ec2-user/insforge-standalone/docker-init/db/postgresql.conf:/etc/postgresql/postgresql.conf:ro
 EnvironmentFile=/etc/insforge/postgres.env
 LogDriver=journald
-StopSignal=SIGINT
-StopTimeout=30
+# Grace period only. The image already declares STOPSIGNAL SIGINT (verified:
+# podman image inspect -> SIGINT), so compose's stop_signal was redundant and
+# there is nothing to restate — what compose did add is stop_grace_period 30s
+# against a container default of 10s. Passed as a podman arg rather than the
+# StopTimeout= key, which podman 4.9's quadlet does not parse: adding it made
+# the generator drop this unit entirely, so `systemctl restart` reported
+# "insforge-postgres.service not found" while the previously generated unit kept
+# running and everything looked fine.
 HealthCmd=pg_isready -U postgres -d insforge -h 127.0.0.1
 HealthInterval=10s
 HealthRetries=30
 HealthStartPeriod=60s
-PodmanArgs=--network-alias=postgres
+PodmanArgs=--network-alias=postgres --stop-timeout=30
 # max_connections and app.encryption_key are stamped here by
 # insforge-render-env from .env on every start -- they cannot be read from the
 # EnvironmentFile because they are server start parameters, and they cannot be

--- a/systemd/insforge-postgres.container
+++ b/systemd/insforge-postgres.container
@@ -1,0 +1,36 @@
+[Unit]
+Description=InsForge Postgres (quadlet)
+After=network-online.target
+Wants=network-online.target
+
+[Container]
+ContainerName=insforge-postgres
+Image=ghcr.io/insforge/postgres:v15.13.4
+Network=insforge.network
+PublishPort=5432:5432
+Volume=insforge-pgdata:/var/lib/postgresql/data
+Volume=/home/ec2-user/insforge-standalone/docker-init/db/db-init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
+Volume=/home/ec2-user/insforge-standalone/docker-init/db/jwt.sql:/docker-entrypoint-initdb.d/02-jwt.sql:ro
+Volume=/home/ec2-user/insforge-standalone/docker-init/db/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+EnvironmentFile=/etc/insforge/postgres.env
+LogDriver=journald
+HealthCmd=pg_isready -U postgres -d insforge -h 127.0.0.1
+HealthInterval=10s
+HealthRetries=30
+HealthStartPeriod=60s
+PodmanArgs=--network-alias=postgres
+# max_connections and app.encryption_key are stamped here by
+# insforge-render-env from .env on every start -- they cannot be read from the
+# EnvironmentFile because they are server start parameters, and they cannot be
+# constants because auto-scale-memory.sh sizes max_connections per instance
+# tier. app.encryption_key is what schedules.encrypt_headers/decrypt_headers
+# read via current_setting(); without it, scheduled functions with headers
+# raise. Compose passed both on the command line for the same reasons.
+Exec=postgres -c config_file=/etc/postgresql/postgresql.conf -c max_connections=100
+
+[Service]
+Restart=always
+TimeoutStartSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/insforge-postgres.container
+++ b/systemd/insforge-postgres.container
@@ -14,6 +14,8 @@ Volume=/home/ec2-user/insforge-standalone/docker-init/db/jwt.sql:/docker-entrypo
 Volume=/home/ec2-user/insforge-standalone/docker-init/db/postgresql.conf:/etc/postgresql/postgresql.conf:ro
 EnvironmentFile=/etc/insforge/postgres.env
 LogDriver=journald
+StopSignal=SIGINT
+StopTimeout=30
 HealthCmd=pg_isready -U postgres -d insforge -h 127.0.0.1
 HealthInterval=10s
 HealthRetries=30
@@ -31,6 +33,12 @@ Exec=postgres -c config_file=/etc/postgresql/postgresql.conf -c max_connections=
 [Service]
 Restart=always
 TimeoutStartSec=300
+# Match compose's stop_signal/stop_grace_period (docker-compose.yml:45-46).
+# Default SIGTERM is postgres' "smart shutdown": it waits for clients to
+# disconnect, so under load systemd's timeout expires and SIGKILL lands, which
+# means crash recovery on the next start. SIGINT is fast shutdown. TimeoutStopSec
+# is above podman's own stop timeout so systemd is not the one that gives up.
+TimeoutStopSec=45
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/insforge-postgrest.container
+++ b/systemd/insforge-postgrest.container
@@ -1,0 +1,26 @@
+[Unit]
+Description=InsForge PostgREST (quadlet)
+After=insforge-postgres.service
+Requires=insforge-postgres.service
+
+[Container]
+ContainerName=insforge-postgrest
+Image=docker.io/postgrest/postgrest:v12.2.12
+Network=insforge.network
+PublishPort=5430:3000
+EnvironmentFile=/etc/insforge/postgrest.env
+LogDriver=journald
+PodmanArgs=--network-alias=postgrest
+# The GHC heap cap is stamped by insforge-render-env from POSTGREST_RTS_HEAP
+# (auto-scale-memory.sh sizes it per tier as POSTGREST_MEMORY - 20M). Pinning
+# it would leave postgrest heap-starved relative to its cgroup allowance on
+# anything above nano.
+Exec=postgrest +RTS -M30M -A2m -H24m -N1 -RTS
+
+[Service]
+Restart=always
+# Gate on the DB actually accepting connections (podman 4.9 has no Notify=healthy)
+ExecStartPre=/bin/sh -c 'for i in $(seq 1 60); do /usr/bin/pg_isready -q -h 127.0.0.1 -p 5432 && exit 0; sleep 2; done; exit 1'
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/insforge-postgrest.container
+++ b/systemd/insforge-postgrest.container
@@ -19,6 +19,10 @@ Exec=postgrest +RTS -M30M -A2m -H24m -N1 -RTS
 
 [Service]
 Restart=always
+# The pg_isready gate below runs up to 120s; systemd's default start timeout is
+# 90s, so without this postgrest is killed mid-wait on a slow first boot and
+# Restart=always turns that into a flap instead of a wait.
+TimeoutStartSec=300
 # Gate on the DB actually accepting connections (podman 4.9 has no Notify=healthy)
 ExecStartPre=/bin/sh -c 'for i in $(seq 1 60); do /usr/bin/pg_isready -q -h 127.0.0.1 -p 5432 && exit 0; sleep 2; done; exit 1'
 

--- a/systemd/insforge-render-env
+++ b/systemd/insforge-render-env
@@ -60,20 +60,28 @@ LOGS_DIR=/insforge-logs
 MAX_JSON_BODY_SIZE=100mb
 MAX_URLENCODED_BODY_SIZE=10mb
 API_BASE_URL=${VITE_API_BASE_URL:-}
-AWS_REGION=${AWS_REGION:-us-east-2}
+AWS_REGION=us-east-2
 POSTGREST_MAX_SOCKETS=${PGRST_DB_POOL:-30}
 PORT=${PORT:-7130}
 POSTGRES_PORT=${POSTGRES_PORT:-5432}
 GOOGLE_REDIRECT_URI=${GOOGLE_REDIRECT_URI:-http://localhost:7130/api/auth/v1/callback}
 GITHUB_REDIRECT_URI=${GITHUB_REDIRECT_URI:-http://localhost:7130/api/auth/v1/callback}
 EOF
-# The four above are keys docker-compose.yml supplies a literal default for
-# (:112, :121, :138, :141). The control plane writes all four into .env today,
-# so on a cloud instance these expand to the same values it already set — they
-# are here so that an .env *missing* one behaves the way compose does instead of
-# leaving it unset and relying on the image's internal default happening to
-# match. Later assignments win in an EnvironmentFile, so a value from .env is
-# preserved, not overridden.
+# PORT, POSTGRES_PORT and the two redirect URIs are keys docker-compose.yml
+# supplies a literal default for (:112, :121, :138, :141). The control plane
+# writes all four into .env today, so on a cloud instance these expand to the
+# same values it already set — they are here so that an .env *missing* one
+# behaves the way compose does instead of leaving it unset and relying on the
+# image's internal default happening to match. Later assignments win in an
+# EnvironmentFile, so a value from .env is preserved, not overridden.
+# AWS_REGION is a literal, not ${AWS_REGION:-…}, because it means two different
+# things under one name. .env's AWS_REGION is the *instance's* region (us-west-1
+# for a us-test project) and the host aws CLI uses it; the container needs the
+# region of the shared storage bucket, which is us-east-2. docker-compose.yml:145
+# hardcodes it for exactly this reason. Deriving it from .env instead made every
+# storage upload on a project outside us-east-2 fail with S3 PermanentRedirect,
+# while provisioning, health and backups all stayed green — found by running the
+# E2E suite against a podman project and a compose project side by side.
 
 # --- multi-line secrets ---------------------------------------------------
 # systemd's Environment= accepts a double-quoted string with C-style escapes,

--- a/systemd/insforge-render-env
+++ b/systemd/insforge-render-env
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Renders per-service env files + the multi-line-secret drop-in for the
+# quadlet units, from the project .env written by user-data.
+#
+# Run as ExecStartPre (with "+" for root) or from the provisioning script
+# before starting insforge-stack. Re-running is idempotent and is what makes
+# ".env edited -> restart -> takes effect" work the way it did under compose.
+set -euo pipefail
+
+ENV_FILE=${ENV_FILE:-/home/ec2-user/insforge-standalone/.env}
+OUT=/etc/insforge
+DROPIN=/etc/systemd/system/insforge.service.d
+
+# shellcheck disable=SC1090
+set -a; source "$ENV_FILE"; set +a
+umask 077
+mkdir -p "$OUT" "$DROPIN"
+
+# --- postgres -------------------------------------------------------------
+cat > "$OUT/postgres.env" <<EOF
+POSTGRES_USER=${POSTGRES_USER:-postgres}
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+POSTGRES_DB=${POSTGRES_DB:-insforge}
+EOF
+
+# --- postgrest ------------------------------------------------------------
+cat > "$OUT/postgrest.env" <<EOF
+PGRST_DB_URI=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+PGRST_DB_SCHEMA=public
+PGRST_DB_ANON_ROLE=anon
+PGRST_JWT_SECRET=${JWT_SECRET}
+PGRST_DB_POOL=${PGRST_DB_POOL:-30}
+PGRST_DB_POOL_TIMEOUT=10
+PGRST_DB_POOL_ACQUISITION_TIMEOUT=10
+PGRST_DB_CHANNEL_ENABLED=true
+PGRST_DB_CHANNEL=pgrst
+PGRST_MAX_ROWS=1000
+PGRST_OPENAPI_SERVER_PROXY_URI=http://localhost:3000
+EOF
+
+# --- insforge -------------------------------------------------------------
+# Single-line vars only. Multi-line values (the CloudFront PEM) cannot be
+# expressed in an env-file at all -- neither systemd's EnvironmentFile= nor
+# podman's --env-file parse them -- so they go through the drop-in below.
+# Allowlist real env lines by shape rather than blocklisting PEM bodies: a
+# wrapped base64 tail shorter than 40 chars would slip past a blocklist and
+# land in the env file as a junk variable.
+grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$ENV_FILE" \
+  | grep -v '^AWS_CLOUDFRONT_PRIVATE_KEY=' > "$OUT/insforge.env"
+# POSTGREST_MAX_SOCKETS was a compose literal and is absent from .env; the
+# app's PostgREST connection ceiling has to track the pool auto-scale sized.
+cat >> "$OUT/insforge.env" <<EOF
+POSTGRES_HOST=postgres
+POSTGREST_BASE_URL=http://postgrest:3000
+DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+NODE_ENV=production
+PROJECT_ROOT=/app
+STORAGE_DIR=/insforge-storage
+LOGS_DIR=/insforge-logs
+MAX_JSON_BODY_SIZE=100mb
+MAX_URLENCODED_BODY_SIZE=10mb
+API_BASE_URL=${VITE_API_BASE_URL:-}
+AWS_REGION=${AWS_REGION:-us-east-2}
+POSTGREST_MAX_SOCKETS=${PGRST_DB_POOL:-30}
+EOF
+
+# --- multi-line secrets ---------------------------------------------------
+# systemd's Environment= accepts a double-quoted string with C-style escapes,
+# so the PEM survives as one logical line. The quadlet unit then passes it
+# through with `-e AWS_CLOUDFRONT_PRIVATE_KEY` (no value = inherit from the
+# podman process's environment). Verified byte-for-byte inside the container.
+python3 - "$DROPIN/secrets.conf" <<'PY'
+import os, sys
+out = sys.argv[1]
+pem = os.environ.get("AWS_CLOUDFRONT_PRIVATE_KEY", "")
+esc = pem.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+with open(out, "w") as f:
+    f.write("[Service]\n")
+    if esc:
+        f.write(f'Environment="AWS_CLOUDFRONT_PRIVATE_KEY={esc}"\n')
+PY
+
+# --- resource limits ------------------------------------------------------
+# auto-scale-memory.sh sizes memory per instance type and writes it to .env.
+# Under compose these were `deploy.resources.limits`; here they become cgroup
+# settings on the generated units, which additionally gives us MemoryHigh --
+# throttle-before-OOM, something compose could not express.
+#
+# Deliberately no CPUQuota. auto-scale-memory.sh removed CPU limits on purpose
+# (see its header: a 0.3-cpu cap on postgrest stalled requests while the host
+# sat at load 0.01) and it strips *_CPUS from .env on every run, so any default
+# here would silently reinstate exactly the cap that was removed. Under
+# contention the kernel's equal cpu.weight arbitrates, as compose now relies on.
+mem_high() { echo "$(( ${1%M} * 90 / 100 ))M"; }
+write_limits() {  # unit, memory
+  mkdir -p "/etc/systemd/system/$1.service.d"
+  cat > "/etc/systemd/system/$1.service.d/limits.conf" <<LIM
+[Service]
+MemoryMax=$2
+MemoryHigh=$(mem_high "$2")
+LIM
+}
+write_limits insforge-postgres  "${POSTGRES_MEMORY:-150M}"
+write_limits insforge-postgrest "${POSTGREST_MEMORY:-50M}"
+write_limits insforge           "${INSFORGE_MEMORY:-150M}"
+
+# --- per-tier values that must live in the unit Exec lines -----------------
+# max_connections, app.encryption_key and the GHC heap cap are server start
+# parameters, so they cannot come from an EnvironmentFile. Stamp them from .env
+# on every render so they track auto-scale-memory.sh instead of drifting as
+# constants (compose passed them on the command line for the same reason).
+QUADLET_DIR=${QUADLET_DIR:-/etc/containers/systemd}
+PG_UNIT="$QUADLET_DIR/insforge-postgres.container"
+PGRST_UNIT="$QUADLET_DIR/insforge-postgrest.container"
+PG_ENC_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
+if [ -f "$PG_UNIT" ]; then
+  sed -i "s|^Exec=postgres .*|Exec=postgres -c config_file=/etc/postgresql/postgresql.conf -c max_connections=${PG_MAX_CONNECTIONS:-100} -c app.encryption_key=${PG_ENC_KEY}|" \
+    "$PG_UNIT"
+fi
+if [ -f "$PGRST_UNIT" ]; then
+  sed -i "s|^Exec=postgrest .*|Exec=postgrest +RTS -M${POSTGREST_RTS_HEAP:-30M} -A2m -H24m -N1 -RTS|" \
+    "$PGRST_UNIT"
+fi
+
+chown 0:0 "$OUT"/*.env "$DROPIN/secrets.conf"
+chmod 400 "$OUT"/*.env "$DROPIN/secrets.conf"
+echo "rendered: $(ls "$OUT"/*.env | tr '\n' ' ') + secrets drop-in"

--- a/systemd/insforge-render-env
+++ b/systemd/insforge-render-env
@@ -62,18 +62,19 @@ MAX_URLENCODED_BODY_SIZE=10mb
 API_BASE_URL=${VITE_API_BASE_URL:-}
 AWS_REGION=us-east-2
 POSTGREST_MAX_SOCKETS=${PGRST_DB_POOL:-30}
-PORT=${PORT:-7130}
-POSTGRES_PORT=${POSTGRES_PORT:-5432}
+PORT=7130
+POSTGRES_PORT=5432
 GOOGLE_REDIRECT_URI=${GOOGLE_REDIRECT_URI:-http://localhost:7130/api/auth/v1/callback}
 GITHUB_REDIRECT_URI=${GITHUB_REDIRECT_URI:-http://localhost:7130/api/auth/v1/callback}
 EOF
-# PORT, POSTGRES_PORT and the two redirect URIs are keys docker-compose.yml
-# supplies a literal default for (:112, :121, :138, :141). The control plane
-# writes all four into .env today, so on a cloud instance these expand to the
-# same values it already set — they are here so that an .env *missing* one
-# behaves the way compose does instead of leaving it unset and relying on the
-# image's internal default happening to match. Later assignments win in an
-# EnvironmentFile, so a value from .env is preserved, not overridden.
+# PORT and POSTGRES_PORT are literals, matching docker-compose.yml:112 and :121
+# exactly — compose ignores whatever .env says for these. `${PORT:-7130}` looked
+# like the more faithful port and is not: a non-default PORT in .env would move
+# the app's listener while insforge.container still publishes 7130:7130, making
+# the project unreachable. The redirect URIs below do use the `${VAR:-default}`
+# form, because that is the form compose uses for them (:138, :141) — the
+# control plane sets them per project. Later assignments win in an
+# EnvironmentFile, so a value from .env is still preserved for those.
 # AWS_REGION is a literal, not ${AWS_REGION:-…}, because it means two different
 # things under one name. .env's AWS_REGION is the *instance's* region (us-west-1
 # for a us-test project) and the host aws CLI uses it; the container needs the

--- a/systemd/insforge-render-env
+++ b/systemd/insforge-render-env
@@ -62,7 +62,18 @@ MAX_URLENCODED_BODY_SIZE=10mb
 API_BASE_URL=${VITE_API_BASE_URL:-}
 AWS_REGION=${AWS_REGION:-us-east-2}
 POSTGREST_MAX_SOCKETS=${PGRST_DB_POOL:-30}
+PORT=${PORT:-7130}
+POSTGRES_PORT=${POSTGRES_PORT:-5432}
+GOOGLE_REDIRECT_URI=${GOOGLE_REDIRECT_URI:-http://localhost:7130/api/auth/v1/callback}
+GITHUB_REDIRECT_URI=${GITHUB_REDIRECT_URI:-http://localhost:7130/api/auth/v1/callback}
 EOF
+# The four above are keys docker-compose.yml supplies a literal default for
+# (:112, :121, :138, :141). The control plane writes all four into .env today,
+# so on a cloud instance these expand to the same values it already set — they
+# are here so that an .env *missing* one behaves the way compose does instead of
+# leaving it unset and relying on the image's internal default happening to
+# match. Later assignments win in an EnvironmentFile, so a value from .env is
+# preserved, not overridden.
 
 # --- multi-line secrets ---------------------------------------------------
 # systemd's Environment= accepts a double-quoted string with C-style escapes,
@@ -113,8 +124,24 @@ QUADLET_DIR=${QUADLET_DIR:-/etc/containers/systemd}
 PG_UNIT="$QUADLET_DIR/insforge-postgres.container"
 PGRST_UNIT="$QUADLET_DIR/insforge-postgrest.container"
 PG_ENC_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
+# The key is a secret of unknown shape — ENCRYPTION_KEY is usually absent and
+# this falls back to JWT_SECRET — and it passes through two parsers on the way
+# in: sed's replacement text, then systemd's Exec= tokenizer. `|` is the sed
+# delimiter and `&` means "the whole match", so either would corrupt the line;
+# whitespace would split the argument and hand postgres a truncated key, which
+# fails at decrypt time rather than at start. Escape for sed, then single-quote
+# for systemd exactly as docker-compose.yml:7 does. A literal single quote
+# cannot be expressed this way, so refuse rather than write a broken unit.
+case "$PG_ENC_KEY" in
+  *"'"*)
+    echo "FATAL: encryption key contains a single quote and cannot be quoted into the unit" >&2
+    exit 1
+    ;;
+esac
+PG_ENC_KEY_SED=$(printf '%s' "$PG_ENC_KEY" | sed -e 's/[\\&|]/\\&/g')
+
 if [ -f "$PG_UNIT" ]; then
-  sed -i "s|^Exec=postgres .*|Exec=postgres -c config_file=/etc/postgresql/postgresql.conf -c max_connections=${PG_MAX_CONNECTIONS:-100} -c app.encryption_key=${PG_ENC_KEY}|" \
+  sed -i "s|^Exec=postgres .*|Exec=postgres -c config_file=/etc/postgresql/postgresql.conf -c max_connections=${PG_MAX_CONNECTIONS:-100} -c app.encryption_key='${PG_ENC_KEY_SED}'|" \
     "$PG_UNIT"
   # This unit now holds the encryption key, so it stops being a world-readable
   # file like the other two. Applied here as well as at install time, because

--- a/systemd/insforge-render-env
+++ b/systemd/insforge-render-env
@@ -53,12 +53,7 @@ cat >> "$OUT/insforge.env" <<EOF
 POSTGRES_HOST=postgres
 POSTGREST_BASE_URL=http://postgrest:3000
 DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
-NODE_ENV=production
 PROJECT_ROOT=/app
-STORAGE_DIR=/insforge-storage
-LOGS_DIR=/insforge-logs
-MAX_JSON_BODY_SIZE=100mb
-MAX_URLENCODED_BODY_SIZE=10mb
 API_BASE_URL=${VITE_API_BASE_URL:-}
 AWS_REGION=us-east-2
 POSTGREST_MAX_SOCKETS=${PGRST_DB_POOL:-30}
@@ -147,6 +142,13 @@ case "$PG_ENC_KEY" in
     exit 1
     ;;
 esac
+# systemd reads % as a specifier introducer on Exec= lines, so a literal % has
+# to be doubled. A key containing %H would otherwise be substituted with the
+# hostname and an unknown specifier fails the unit — either way the key silently
+# stops being the key, which surfaces much later as a decrypt failure. Same
+# reasoning as the single-quote refusal below; JWT_SECRET is caller-supplied on
+# project create and is not guaranteed to be hex.
+PG_ENC_KEY=${PG_ENC_KEY//%/%%}
 PG_ENC_KEY_SED=$(printf '%s' "$PG_ENC_KEY" | sed -e 's/[\\&|]/\\&/g')
 
 if [ -f "$PG_UNIT" ]; then

--- a/systemd/insforge-render-env
+++ b/systemd/insforge-render-env
@@ -116,6 +116,12 @@ PG_ENC_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-productio
 if [ -f "$PG_UNIT" ]; then
   sed -i "s|^Exec=postgres .*|Exec=postgres -c config_file=/etc/postgresql/postgresql.conf -c max_connections=${PG_MAX_CONNECTIONS:-100} -c app.encryption_key=${PG_ENC_KEY}|" \
     "$PG_UNIT"
+  # This unit now holds the encryption key, so it stops being a world-readable
+  # file like the other two. Applied here as well as at install time, because
+  # either step can be the one that ran last. (The key is also in .env at 0644,
+  # which is pre-existing and shared with the compose path — narrowing that is a
+  # separate change, not something this file can fix.)
+  chown 0:0 "$PG_UNIT" && chmod 0600 "$PG_UNIT"
 fi
 if [ -f "$PGRST_UNIT" ]; then
   sed -i "s|^Exec=postgrest .*|Exec=postgrest +RTS -M${POSTGREST_RTS_HEAP:-30M} -A2m -H24m -N1 -RTS|" \

--- a/systemd/insforge.container
+++ b/systemd/insforge.container
@@ -1,0 +1,26 @@
+[Unit]
+Description=InsForge API (quadlet)
+After=insforge-postgres.service
+Requires=insforge-postgres.service
+
+[Container]
+# Default tag mirrors docker-compose.yml on this branch; provisioning
+# overwrites this line from INSFORGE_OSS_VER when the control plane pins a
+# version, and `insforge-ctl upgrade <ver>` rewrites it on every upgrade.
+ContainerName=insforge
+Image=ghcr.io/insforge/insforge-oss:v2.3.0
+Network=insforge.network
+PublishPort=7130:7130
+PublishPort=7131:7131
+EnvironmentFile=/etc/insforge/insforge.env
+LogDriver=journald
+PodmanArgs=-e AWS_CLOUDFRONT_PRIVATE_KEY
+WorkingDir=/app
+
+[Service]
+Restart=always
+TimeoutStartSec=600
+ExecStartPre=/bin/sh -c 'for i in $(seq 1 60); do /usr/bin/pg_isready -q -h 127.0.0.1 -p 5432 && exit 0; sleep 2; done; exit 1'
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/insforge.network
+++ b/systemd/insforge.network
@@ -1,0 +1,2 @@
+[Network]
+NetworkName=insforge


### PR DESCRIPTION
Replaces #114 with the same tree and a reviewable history — that PR had five follow-up commits fixing its own review findings, which made the diff read as a changelog instead of a design. Two commits here: the quadlet units and env rendering, then `insforge-ctl`. The decisions the reviewers pushed back on are now stated in the commit messages rather than buried in fix commits.

Pairs with [insforge-cloud-backend#816](https://github.com/InsForge/insforge-cloud-backend/pull/816), which provisions this profile and routes every control-plane command through `insforge-ctl`.

**Nothing here is reachable until a region's AMI env var points at the Ubuntu image.** All seven files are new; the `docker-compose.yml` path is untouched, so an unchanged instance behaves exactly as it does today.

## Why detection lives on the instance

Pausing terminates the instance. Restoring provisions a **brand-new** one from whatever AMI the region is configured with, so a project created on AL2023 + compose is routinely restored onto Ubuntu + podman with nothing about the project having changed. Any `runtime` column the control plane keeps is wrong after the first restore, and the failure is silent: a `docker-compose` command lands on a host with no docker, the project looks provisioned, and the first restart fails.

So `insforge-ctl` resolves the runtime locally and implements the verbs. Every control-plane command becomes one string that works on both.

## What is in here

| File | What |
|---|---|
| `insforge-ctl` | runtime/status/up/down/restart/restart-app/stop-apps/start-all/upgrade/prune/psql/pg_dump against podman or compose |
| `systemd/*.container`, `*.network` | quadlet units for postgres, postgrest, the app, and their network |
| `systemd/insforge-render-env` | .env → per-service env files, the multi-line-PEM drop-in, memory limit drop-ins, and the stamped Exec lines |
| `systemd/README.md` | layout and the podman-4.9 constraints |

The AMI bake script that was in #114 is **not** here — it moved to insforge-cloud-backend#816, next to the user-data scripts. Rationale: the image is only consumed by the cloud control plane, and its tightest contract is with `podman.sh` (a missing `unzip` in the image killed provisioning three times), not with these units. This repo is also the self-hosting template, where an AWS-specific bake script is noise.

## Verified live, through the staging control plane

Every verb exercised on real instances, not a hand-built box:

- restart completes in 5.3s with health 200; reboot recovers all three units, plus fluent-bit and node_exporter, with 5432 and 7130 still listening
- version update v2.2.2 → v2.3.0 → v2.2.2 with the container image actually changing (the first cut was a silent no-op — see `sync_units` in the second commit)
- backup → 31KB dump in S3, restore → database recreated, migration ledger 66 rows, health 200
- pause → restore, which re-provisions from the current AMI: new instance, runtime podman, data and disk size intact
- instance type nano → micro: volume 8 → 13 GiB with `growpart` + `resize2fs`, and the tier values re-derived (memory limits 162M → 375M)
- **backend branching, including the mixed case this migration actually produces**: a docker parent project with a podman branch, then merged back. A 98,428-byte function created on the podman branch landed on the compose parent through the S3-staged SQL path and executes there.
- **no-op for compose confirmed on a real AL2023 + docker instance**: `insforge-ctl runtime` reports `compose`, `psql` and `pg_dump` work through `compose exec`, the legacy restart path returns health 200, and `app.encryption_key` is still set afterwards

Measured idle footprint on a dedicated untouched project, 19.5 min post-boot: total anonymous memory 173.7 MB on OSS v2.3.0. The earlier 158 MB figure was v2.2.2 — different application version, so the two are not directly comparable and a same-version baseline is still outstanding.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Ubuntu + `podman` runtime profile with `quadlet` units and a new `insforge-ctl` wrapper that auto-detects the runtime so control-plane commands work on both `podman` and `docker-compose`. Hardens unit install by staging and rendering before install to prevent a keyless Postgres unit across reboots, and aligns compose behavior (literal ports, Postgres stop grace/timeouts, `AWS_REGION` set to us-east-2).

- **New Features**
  - `insforge-ctl`: one entrypoint for runtime/status/up/down/restart/restart-app/stop-apps/start-all/upgrade/prune/psql/pg_dump; detects `podman`, compose V1, or compose V2; self-elevates on `podman`; refreshes the root-owned `/usr/local/bin/insforge-ctl` on restart.
  - Quadlet units: `insforge`, `insforge-postgres`, `insforge-postgrest`, plus `insforge.network`; `--network-alias` for `postgres`/`postgrest`; DB readiness via `pg_isready`; Postgres uses image `STOPSIGNAL SIGINT` with `PodmanArgs=--stop-timeout=30` and `TimeoutStopSec=45`; PostgREST `TimeoutStartSec=300`.
  - Env/render: per-service env files (0400), cgroup memory limits (MemoryMax/MemoryHigh), CloudFront PEM as a systemd drop-in, and stamped Exec lines (image tag, `max_connections`, PostgREST RTS heap). Escapes `app.encryption_key` (refuses single quotes; doubles `%`), sets literal `PORT`/`POSTGRES_PORT`, preserves OAuth redirect URIs, sets `AWS_REGION` to us-east-2, drops image-provided env. Stages units under `/run`, renders, then swaps into `/etc/containers/systemd` and reloads — a failed render cannot persist across a reboot.
  - Sync/warnings: unit/image/ctl sync on restart and `upgrade <version>`; warns on uncommitted or untracked changes under `systemd/` or `insforge-ctl`.

- **Migration**
  - No action for AL2023 + compose hosts; `docker-compose.yml` is untouched.
  - To enable `podman`: point the region AMI to the Ubuntu image; provisioning installs the `quadlet` units and `insforge-ctl`.
  - Route all instance actions through `insforge-ctl` so paused/restored projects keep working across runtime changes.

<sup>Written for commit a8a69c58cbf733dc948b4645f9854f0bcfb03c3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `insforge-ctl` commands for starting, stopping, upgrading, pruning, database management, and status checks.
  * Added support for Podman with systemd, Docker Compose V1, and Compose V2.
  * Added managed PostgreSQL, PostgREST, and InsForge API services with automatic restarts, health checks, networking, and persistent storage.
  * Added automatic environment configuration, secure secret handling, resource limits, and image synchronization.
* **Documentation**
  * Added Ubuntu 24.04 and Podman setup guidance, including prerequisites, permissions, startup behavior, and configuration warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->