### PR TITLE
Strip .env's quotes when generating the podman EnvironmentFile

### DIFF
--- a/systemd/insforge-render-env
+++ b/systemd/insforge-render-env
@@ -45,8 +45,19 @@ EOF
 # Allowlist real env lines by shape rather than blocklisting PEM bodies: a
 # wrapped base64 tail shorter than 40 chars would slip past a blocklist and
 # land in the env file as a junk variable.
+# The sed strips one layer of surrounding double quotes. .env quotes its values
+# because it is read with `source` in several places, where an unquoted space or
+# `;` would execute rather than assign. This file is the opposite: systemd's
+# EnvironmentFile= and podman's --env-file do not do shell parsing, and they do
+# NOT strip quotes — verified on a live instance, where a probe written as
+# KEY="a b;c" reached the container complete with its quotes. Copying .env
+# verbatim would therefore hand the app JWT_SECRET="…" while postgrest.env, which
+# is written from the sourced value, gets it clean: every PostgREST token check
+# would fail. A value cannot itself contain a double quote — the API rejects
+# that — so unwrapping one layer is unambiguous.
 grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$ENV_FILE" \
-  | grep -v '^AWS_CLOUDFRONT_PRIVATE_KEY=' > "$OUT/insforge.env"
+  | grep -v '^AWS_CLOUDFRONT_PRIVATE_KEY=' \
+  | sed -E 's/^([A-Za-z_][A-Za-z0-9_]*)="(.*)"$/\1=\2/' > "$OUT/insforge.env"
 # POSTGREST_MAX_SOCKETS was a compose literal and is absent from .env; the
 # app's PostgREST connection ceiling has to track the pool auto-scale sized.
 cat >> "$OUT/insforge.env" <<EOF

--- a/systemd/insforge-render-env
+++ b/systemd/insforge-render-env
@@ -45,19 +45,35 @@ EOF
 # Allowlist real env lines by shape rather than blocklisting PEM bodies: a
 # wrapped base64 tail shorter than 40 chars would slip past a blocklist and
 # land in the env file as a junk variable.
-# The sed strips one layer of surrounding double quotes. .env quotes its values
-# because it is read with `source` in several places, where an unquoted space or
-# `;` would execute rather than assign. This file is the opposite: systemd's
-# EnvironmentFile= and podman's --env-file do not do shell parsing, and they do
-# NOT strip quotes — verified on a live instance, where a probe written as
-# KEY="a b;c" reached the container complete with its quotes. Copying .env
-# verbatim would therefore hand the app JWT_SECRET="…" while postgrest.env, which
-# is written from the sourced value, gets it clean: every PostgREST token check
-# would fail. A value cannot itself contain a double quote — the API rejects
-# that — so unwrapping one layer is unambiguous.
-grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$ENV_FILE" \
-  | grep -v '^AWS_CLOUDFRONT_PRIVATE_KEY=' \
-  | sed -E 's/^([A-Za-z_][A-Za-z0-9_]*)="(.*)"$/\1=\2/' > "$OUT/insforge.env"
+# Emit the values bash parsed, not the text they were written as.
+#
+# .env is shell input: `source` resolves quoting and escaping, so the only
+# faithful representation of a value is the variable's contents. This file is the
+# opposite — systemd's EnvironmentFile= and podman's --env-file do no shell
+# parsing and do not strip anything (verified: a probe written as KEY="a b;c"
+# reached the container with its quotes). Copying .env's text across, with or
+# without unwrapping delimiters, gets the common case right and then quietly
+# disagrees with postgres.env/postgrest.env — which are written from the sourced
+# values — for anything single-quoted or escaped. Same secret, two strings, and
+# the symptom is every PostgREST token check failing on a box that reports
+# healthy. Reading the variables removes the whole class instead of the cases
+# someone thought of.
+#
+# The PEM is excluded because no env-file format can carry a newline; it goes
+# through the systemd drop-in below. Any other multi-line value would corrupt
+# this file the same way, so it is skipped loudly rather than written.
+: > "$OUT/insforge.env"
+while IFS= read -r key; do
+  [ "$key" = AWS_CLOUDFRONT_PRIVATE_KEY ] && continue
+  value=${!key-}
+  case $value in
+    *$'\n'*)
+      echo "insforge-render-env: skipping multi-line value for $key" >&2
+      continue
+      ;;
+  esac
+  printf '%s=%s\n' "$key" "$value" >> "$OUT/insforge.env"
+done < <(sed -nE 's/^([A-Za-z_][A-Za-z0-9_]*)=.*/\1/p' "$ENV_FILE" | awk '!seen[$0]++')
 # POSTGREST_MAX_SOCKETS was a compose literal and is absent from .env; the
 # app's PostgREST connection ceiling has to track the pool auto-scale sized.
 cat >> "$OUT/insforge.env" <<EOF


### PR DESCRIPTION
Fixes a live gap introduced by the control-plane side quoting `.env`. No production impact — there are no podman instances there yet — but the next one provisioned would hit it.

## What breaks

`.env` now quotes its values, because it is read with `source` in several places where an unquoted space or `;` would execute rather than assign. `insforge.env` is the opposite kind of file: systemd's `EnvironmentFile=` and podman's `--env-file` do no shell parsing, and **they do not strip quotes**. I assumed they did; they do not. Verified on a live instance with a probe:

```
.env:       QUOTE_PROBE="probe value;with-meta"
container:  ["probe value;with-meta"]      <- quotes intact
```

Because `insforge.env` is a verbatim `grep` of `.env`, the app receives `JWT_SECRET="…"` while `postgrest.env` — written from the *sourced* value, so already clean — gets it without. Same secret, two different strings: every PostgREST token check fails, on an instance that reports healthy and passes `/api/health`. `POSTGRES_PASSWORD` has the same shape.

## The fix

One layer of surrounding double quotes is stripped on the way into `insforge.env`. A value cannot itself contain a double quote — the API rejects that character — so unwrapping is unambiguous. `postgres.env` and `postgrest.env` are untouched: they are written from sourced values and were always clean.

Verified end to end on a live podman instance, with `.env` holding the quoted form:

```
.env       JWT_SECRET="1f6aa…"
app        [1f6aaa] len=40
postgrest  [1f6aaa] len=40
health 200
```

Before the fix the app side would have been 42 characters, quotes included.

## Why the two files want opposite things

Worth stating, since it is the kind of asymmetry that invites a "consistency" cleanup later: `.env` is **shell input** and must quote, or a space becomes a command. `insforge.env` is a **key/value file for systemd and podman** and must not, or the quotes become part of the value. They are different formats that happen to look alike.

Pairs with the control-plane change that quotes the remaining interpolated values; this should land first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate `insforge.env` from sourced `.env` variables so `systemd`/`podman` get the actual values, not quoted or escaped text. This replaces quote-stripping and fixes secret mismatches (e.g., `JWT_SECRET`, `POSTGRES_PASSWORD`) that broke PostgREST auth on new instances.

- Read keys from `.env` and write `key=value` using the shell-parsed value; quoting style and escapes no longer affect output.
- Skip multi-line values with a stderr message; continue excluding `AWS_CLOUDFRONT_PRIVATE_KEY` (handled via the systemd drop-in).
- De-duplicate keys and keep allowlist-by-key-shape filtering; `postgres.env` and `postgrest.env` remain unchanged.

<sup>Written for commit 6635d3d61f0c4b23cd509f2d2cf7561486410051. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment configuration generation now removes the CloudFront private key entry.
  * Values sourced from environment files are written without one surrounding pair of double quotes.
  * Existing environment-variable filtering behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->