### PR TITLE
Fix the two script paths nothing overrides

### DIFF
--- a/insforge-ctl
+++ b/insforge-ctl
@@ -5,15 +5,25 @@
 # (AL2023 + docker-compose, and Ubuntu + podman/quadlet), and an instance can
 # switch from one to the other without warning — a paused project's restore
 # provisions a brand-new instance from whatever AMI is current, so a project
-# created under compose can come back under podman. Encoding the runtime in
-# the control plane (a DB flag, a per-project branch) means two sources of
-# truth that eventually disagree. Instead the instance reports what it is:
-# every caller runs the same verbs here and this script picks the mechanism.
+# created under compose can come back under podman. Every caller runs the same
+# verbs here and this script picks the mechanism.
+#
+# The detection below is deliberately not a lookup of something someone wrote
+# down. The control plane does record a runtime per deployment, because it has
+# to compose an SSM command before it can reach the instance at all — but that
+# is a different question from this one. This script runs *on* the box, where
+# the box itself is the cheapest and most current answer, and it is also what
+# you reach for by hand when something is already wrong. A tool that trusted a
+# label at that moment would be trusting the one thing an incident makes stale.
 #
 # Callers: the cloud control plane over SSM, and the backup/restore scripts.
 set -euo pipefail
 
-PROJECT_DIR=${INSFORGE_PROJECT_DIR:-/home/ec2-user/insforge-standalone}
+# Hardcoded, like the nine other places that name it: the control plane's
+# workingDir and podman.sh both fix this path, so an override here could only
+# ever point this script at a different checkout than the one holding the units
+# it manages and the one the caller cd'd into.
+PROJECT_DIR=/home/ec2-user/insforge-standalone
 QUADLET_MARKER=/etc/containers/systemd/insforge-postgres.container
 APP_UNITS=(insforge-postgres insforge-postgrest insforge)
 

--- a/systemd/insforge-render-env
+++ b/systemd/insforge-render-env
@@ -7,7 +7,7 @@
 # ".env edited -> restart -> takes effect" work the way it did under compose.
 set -euo pipefail
 
-ENV_FILE=${ENV_FILE:-/home/ec2-user/insforge-standalone/.env}
+ENV_FILE=/home/ec2-user/insforge-standalone/.env
 OUT=/etc/insforge
 DROPIN=/etc/systemd/system/insforge.service.d
 


### PR DESCRIPTION
Two `${VAR:-default}` knobs with no setter anywhere, plus a header comment that argues against something we now do.

### `INSFORGE_PROJECT_DIR` and `ENV_FILE`

Searched both repos — nothing sets either one. `insforge-render-env` has exactly two callers and neither passes `ENV_FILE`:

- `podman.sh:226` — bare invocation
- `insforge-ctl` `sync_and_render` — passes `QUADLET_DIR` only

They were escape hatches from testing the render path in isolation (they're how the `.env` quoting round-trip got verified). Nothing turns them now.

`INSFORGE_PROJECT_DIR` is the weaker of the two on a second count: it's the only place in the system that treats that path as variable. The control plane fixes it in `app.config.ts`, and `podman.sh` names it literally nine times. Setting it could only point this script at a different checkout than the one holding the units it manages and the one the caller `cd`'d into — a silent split-brain, reachable by nothing.

### `QUADLET_DIR` stays

It has exactly one setter, `sync_and_render`, which renders into a staging directory and moves the result into place only once the render succeeded. That's the fix for the keyless-unit-on-next-boot problem, not a knob.

### The header comment

It claimed that recording the runtime in the control plane would mean two sources of truth that eventually disagree. The control plane does record it now — it has to compose an SSM command before it can reach the instance at all. That's a different question from the one this script answers, which is what the box in front of it actually is. Left as-is, the comment reads as an argument against the shipped design.

### Risk

`${VAR:-X}` → `X` with `VAR` unset everywhere is a no-op substitution. `bash -n` passes on both files. `insforge-ctl` refreshes itself from the checkout on every restart, so this reaches existing instances without a redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardcodes previously unused `INSFORGE_PROJECT_DIR` and `ENV_FILE` paths to `/home/ec2-user/insforge-standalone` and updates the runtime-detection header to match current control plane behavior. Previously the scripts allowed `${VAR:-default}` overrides; now they ignore those vars (none are set), preventing mispointing while keeping `QUADLET_DIR` for staged renders.

- Changes: `insforge-ctl` sets `PROJECT_DIR` directly and clarifies on-box detection vs control-plane recording; `systemd/insforge-render-env` sets `ENV_FILE` directly.
- Rollout: No migration needed; no callers set the removed vars. Risk is low because `${VAR:-X}` → `X` is a no-op when unset, and `insforge-ctl` self-refreshes on restart.

<sup>Written for commit 5a3b0dbcef5defc82deee652f8034cb185a9bc90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-standalone/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

