### PR TITLE
Make docker-compose.yml the only place the app version is declared

### DIFF
--- a/insforge-ctl
+++ b/insforge-ctl
@@ -164,41 +164,25 @@ sync_and_render() {
   install -m 0644 "$src/insforge.container" "$src/insforge-postgrest.container" "$stage"/
   install -m 0600 "$src/insforge-postgres.container" "$stage"/
 
+  # Version: .env's pin, else the default docker-compose.yml declares. Compose is
+  # the only place it is declared — a tag in insforge.container would be a second
+  # place to bump at release time, and v2.3.1 bumped compose and missed it.
+  # `|| true`: this script runs under pipefail, and grep exits 1 when .env has no
+  # INSFORGE_OSS_VER line at all.
   local ver
-  # `|| true` is load-bearing: this script runs under `set -o pipefail`, so when
-  # .env has no INSFORGE_OSS_VER line at all, grep's exit 1 propagates out of the
-  # pipeline and the assignment aborts the whole script — before anything is
-  # rendered, with no message beyond exit 1. It survives today only because the
-  # provisioning script always writes the key, empty value included. That is a
-  # property of a file the control plane rewrites, not something to rely on.
   ver=$(grep -E '^INSFORGE_OSS_VER=' "$PROJECT_DIR/.env" 2>/dev/null | cut -d= -f2 || true)
   if [ -z "$ver" ]; then
-    # No pinned version: fall back to the one docker-compose.yml declares, not
-    # to whatever tag insforge.container happens to carry.
-    #
-    # The control plane leaves INSFORGE_OSS_VER empty whenever nobody named a
-    # version — on create, and on every restore-from-pause — and compose
-    # resolves that to its own ${INSFORGE_OSS_VER:-vX} literal. Reading the same
-    # literal is what keeps the two runtimes on one version. While the unit's own
-    # tag was the fallback instead, the two drifted the moment a release bumped
-    # one and not the other: v2.3.1 changed only docker-compose.yml, so new
-    # podman projects came up a release behind, and pausing then restoring a
-    # podman project silently downgraded it from v2.3.1 to v2.3.0. The unit keeps
-    # a tag so `systemctl start` works without this script; it just stops being
-    # the version anything resolves to.
-    #
-    # Same `|| true` for the same reason as above: sed exits 2 on a missing file
-    # and pipefail would turn an unreadable docker-compose.yml into a silent
-    # abort of the whole render. Falling through with an empty ver leaves the
-    # unit's own tag in place, which is the right degradation.
     ver=$(sed -nE 's|^[[:space:]]*image:[[:space:]]*ghcr\.io/insforge/insforge-oss:\$\{INSFORGE_OSS_VER:-([^}]+)\}.*|\1|p' \
       "$PROJECT_DIR/docker-compose.yml" 2>/dev/null | head -1 || true)
   fi
-  if [ -n "$ver" ]; then
-    sed -i "s|^Image=ghcr.io/insforge/insforge-oss:.*|Image=ghcr.io/insforge/insforge-oss:${ver}|" \
-      "$stage/insforge.container"
-    podman pull "ghcr.io/insforge/insforge-oss:${ver}" >/dev/null 2>&1 || true
-  fi
+  # Refuse rather than install the unstamped placeholder over a working unit.
+  [ -n "$ver" ] || {
+    echo "insforge-ctl: no app version in .env or docker-compose.yml" >&2
+    exit 1
+  }
+  sed -i "s|^Image=ghcr.io/insforge/insforge-oss:.*|Image=ghcr.io/insforge/insforge-oss:${ver}|" \
+    "$stage/insforge.container"
+  podman pull "ghcr.io/insforge/insforge-oss:${ver}" >/dev/null 2>&1 || true
 
   # Stamps the staged units and writes the env files / drop-ins. set -e aborts
   # here on failure, before anything reaches $live.

--- a/insforge-ctl
+++ b/insforge-ctl
@@ -165,7 +165,35 @@ sync_and_render() {
   install -m 0600 "$src/insforge-postgres.container" "$stage"/
 
   local ver
-  ver=$(grep -E '^INSFORGE_OSS_VER=' "$PROJECT_DIR/.env" 2>/dev/null | cut -d= -f2)
+  # `|| true` is load-bearing: this script runs under `set -o pipefail`, so when
+  # .env has no INSFORGE_OSS_VER line at all, grep's exit 1 propagates out of the
+  # pipeline and the assignment aborts the whole script — before anything is
+  # rendered, with no message beyond exit 1. It survives today only because the
+  # provisioning script always writes the key, empty value included. That is a
+  # property of a file the control plane rewrites, not something to rely on.
+  ver=$(grep -E '^INSFORGE_OSS_VER=' "$PROJECT_DIR/.env" 2>/dev/null | cut -d= -f2 || true)
+  if [ -z "$ver" ]; then
+    # No pinned version: fall back to the one docker-compose.yml declares, not
+    # to whatever tag insforge.container happens to carry.
+    #
+    # The control plane leaves INSFORGE_OSS_VER empty whenever nobody named a
+    # version — on create, and on every restore-from-pause — and compose
+    # resolves that to its own ${INSFORGE_OSS_VER:-vX} literal. Reading the same
+    # literal is what keeps the two runtimes on one version. While the unit's own
+    # tag was the fallback instead, the two drifted the moment a release bumped
+    # one and not the other: v2.3.1 changed only docker-compose.yml, so new
+    # podman projects came up a release behind, and pausing then restoring a
+    # podman project silently downgraded it from v2.3.1 to v2.3.0. The unit keeps
+    # a tag so `systemctl start` works without this script; it just stops being
+    # the version anything resolves to.
+    #
+    # Same `|| true` for the same reason as above: sed exits 2 on a missing file
+    # and pipefail would turn an unreadable docker-compose.yml into a silent
+    # abort of the whole render. Falling through with an empty ver leaves the
+    # unit's own tag in place, which is the right degradation.
+    ver=$(sed -nE 's|^[[:space:]]*image:[[:space:]]*ghcr\.io/insforge/insforge-oss:\$\{INSFORGE_OSS_VER:-([^}]+)\}.*|\1|p' \
+      "$PROJECT_DIR/docker-compose.yml" 2>/dev/null | head -1 || true)
+  fi
   if [ -n "$ver" ]; then
     sed -i "s|^Image=ghcr.io/insforge/insforge-oss:.*|Image=ghcr.io/insforge/insforge-oss:${ver}|" \
       "$stage/insforge.container"

--- a/systemd/insforge.container
+++ b/systemd/insforge.container
@@ -8,7 +8,10 @@ Requires=insforge-postgres.service
 # overwrites this line from INSFORGE_OSS_VER when the control plane pins a
 # version, and `insforge-ctl upgrade <ver>` rewrites it on every upgrade.
 ContainerName=insforge
-Image=ghcr.io/insforge/insforge-oss:v2.3.0
+# Stamped by insforge-ctl from .env / docker-compose.yml on every up and
+# restart. Not a version to keep in sync: nothing starts this unit before that
+# has happened, and a real tag here would just be a second place to bump.
+Image=ghcr.io/insforge/insforge-oss:stamped-by-insforge-ctl
 Network=insforge.network
 PublishPort=7130:7130
 PublishPort=7131:7131


### PR DESCRIPTION
A podman project with no pinned version came up one release behind, and pausing then restoring one silently downgraded it v2.3.1 → v2.3.0. Found by running a full lifecycle against a real podman project on staging.

The control plane leaves `INSFORGE_OSS_VER` empty whenever nobody names a version — on create, and on every restore-from-pause. Compose resolves that to its own `${INSFORGE_OSS_VER:-vX}` default; `sync_and_render` instead left `insforge.container`'s tag alone. Two literals, and release v2.3.1 bumped only compose (`git show --stat` on #116: one file).

So `sync_and_render` now resolves from `.env`, else from compose, and the unit's tag becomes a placeholder. It only ever applied when nothing ran `insforge-ctl`, and provisioning's last step is `insforge-ctl up` — it was always overwritten before first use. Keeping a real version there only gave release day a second place to miss.

If neither source yields a version, it refuses with a message rather than continuing: `sync_and_render` installs the staged unit over the live one, so falling through would stamp the placeholder onto a working unit.

One `|| true` remains and is load-bearing — the script runs under `pipefail` and `grep` exits 1 when `.env` has no `INSFORGE_OSS_VER` line at all, which aborted the whole render before anything was written.

### Verified

Live podman project, same `.env` with `INSFORGE_OSS_VER` empty: old script stamped `v2.3.0`, fixed script stamped `v2.3.1`, and after a restart the container ran `insforge-oss:v2.3.1` with `/api/health` reporting 2.3.1.

Four cases exercised on the resolution logic: pinned value, empty value, key absent, compose unreadable (refuses).

Re-verification of this revision on the instance is pending — AWS creds expired mid-run. The behaviour change since the verified revision is the placeholder plus the refusal; resolution itself is unchanged and covered above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)